### PR TITLE
test: add comprehensive test coverage for issue #26 My Attestations page

### DIFF
--- a/tests/app/dashboard/page.test.tsx
+++ b/tests/app/dashboard/page.test.tsx
@@ -1,11 +1,13 @@
 import React from 'react'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import DashboardPage from '@/app/dashboard/page'
+import type { EnrichedAttestationResult } from '@/lib/attestation-queries'
 
 const mockUseWallet = vi.fn()
 const mockUseActiveAccount = vi.fn()
 const mockGetAttestationsByAttesterWithMetadata = vi.fn()
+const mockRevokeAttestation = vi.fn()
 
 vi.mock('thirdweb/react', () => ({
   useActiveAccount: () => mockUseActiveAccount(),
@@ -14,7 +16,7 @@ vi.mock('thirdweb/react', () => ({
 vi.mock('thirdweb/adapters/ethers6', () => ({
   ethers6Adapter: {
     signer: {
-      toEthers: vi.fn(),
+      toEthers: vi.fn().mockResolvedValue({ provider: {} }),
     },
   },
 }))
@@ -22,22 +24,85 @@ vi.mock('thirdweb/adapters/ethers6', () => ({
 vi.mock('@/lib/blockchain', () => ({
   useWallet: () => mockUseWallet(),
   getActiveThirdwebChain: () => ({ id: 66238 }),
+  getActiveChain: () => ({ id: 66238, rpc: 'https://rpc.testnet.chain.oma3.org/' }),
 }))
 
 vi.mock('@/lib/attestation-queries', () => ({
   getAttestationsByAttesterWithMetadata: (...args: unknown[]) => mockGetAttestationsByAttesterWithMetadata(...args),
 }))
 
+vi.mock('@oma3/omatrust/reputation', () => ({
+  revokeAttestation: (...args: unknown[]) => mockRevokeAttestation(...args),
+}))
+
+const mockGetChainById = vi.fn()
+const mockGetContractAddress = vi.fn()
+
+vi.mock('@/config/chains', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/config/chains')>()
+  return {
+    ...actual,
+    getChainById: (...args: unknown[]) => mockGetChainById(...args),
+  }
+})
+
+vi.mock('@/config/attestation-services', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/config/attestation-services')>()
+  return {
+    ...actual,
+    getContractAddress: (...args: unknown[]) => mockGetContractAddress(...args),
+  }
+})
+
+const WALLET_ADDRESS = '0x1111111111111111111111111111111111111111'
+const OTHER_ADDRESS = '0x2222222222222222222222222222222222222222'
+
+function makeAttestation(overrides: Partial<EnrichedAttestationResult> = {}): EnrichedAttestationResult {
+  return {
+    uid: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    schema: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+    attester: WALLET_ADDRESS,
+    recipient: '0x9999999999999999999999999999999999999999',
+    data: '0x',
+    time: 1735689600,
+    expirationTime: 0,
+    revocationTime: 0,
+    refUID: '0x0000000000000000000000000000000000000000000000000000000000000000',
+    revocable: true,
+    schemaId: 'linked-identifier',
+    schemaTitle: 'Linked Identifier',
+    decodedData: { subject: 'did:web:example.com' },
+    ...overrides,
+  }
+}
+
+function setupConnected() {
+  mockUseWallet.mockReturnValue({
+    isConnected: true,
+    address: WALLET_ADDRESS,
+    chainId: 66238,
+  })
+}
+
 describe('Dashboard Page', () => {
   beforeEach(() => {
-    mockUseActiveAccount.mockReturnValue({ address: '0x1111111111111111111111111111111111111111' })
+    vi.clearAllMocks()
+    mockUseActiveAccount.mockReturnValue({ address: WALLET_ADDRESS })
     mockGetAttestationsByAttesterWithMetadata.mockResolvedValue([])
     mockUseWallet.mockReturnValue({
       isConnected: false,
       address: null,
       chainId: 66238,
     })
+    mockGetChainById.mockReturnValue({
+      id: 66238,
+      name: 'OMAchain Testnet',
+      blockExplorers: [{ name: 'Explorer', url: 'https://explorer.testnet.chain.oma3.org' }],
+    })
+    mockGetContractAddress.mockReturnValue('0x' + 'e'.repeat(40))
   })
+
+  // ── Disconnected state ──────────────────────────────────────────────
 
   it('renders connect-wallet prompt when disconnected', () => {
     render(<DashboardPage />)
@@ -45,31 +110,16 @@ describe('Dashboard Page', () => {
     expect(screen.getByText(/connect your wallet to view and revoke your attestations/i)).toBeInTheDocument()
   })
 
+  it('does not call getAttestationsByAttester when disconnected', () => {
+    render(<DashboardPage />)
+    expect(mockGetAttestationsByAttesterWithMetadata).not.toHaveBeenCalled()
+  })
+
+  // ── Connected state – table rendering ───────────────────────────────
+
   it('renders attestation table headings when connected', async () => {
-    mockUseWallet.mockReturnValue({
-      isConnected: true,
-      address: '0x1111111111111111111111111111111111111111',
-      chainId: 66238,
-    })
-    mockGetAttestationsByAttesterWithMetadata.mockResolvedValue([
-      {
-        uid: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-        schema: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
-        attester: '0x1111111111111111111111111111111111111111',
-        recipient: '0x9999999999999999999999999999999999999999',
-        data: '0x',
-        time: 1735689600,
-        expirationTime: 0,
-        revocationTime: 0,
-        refUID: '0x0000000000000000000000000000000000000000000000000000000000000000',
-        revocable: true,
-        schemaId: 'linked-identifier',
-        schemaTitle: 'Linked Identifier',
-        decodedData: {
-          subject: 'did:web:example.com',
-        },
-      },
-    ])
+    setupConnected()
+    mockGetAttestationsByAttesterWithMetadata.mockResolvedValue([makeAttestation()])
 
     render(<DashboardPage />)
 
@@ -82,5 +132,464 @@ describe('Dashboard Page', () => {
     expect(screen.getByText(/recipient/i)).toBeInTheDocument()
     expect(screen.getByText(/status/i)).toBeInTheDocument()
     expect(screen.getByText(/action/i)).toBeInTheDocument()
+  })
+
+  it('calls getAttestationsByAttesterWithMetadata with connected wallet address', async () => {
+    setupConnected()
+    mockGetAttestationsByAttesterWithMetadata.mockResolvedValue([])
+
+    render(<DashboardPage />)
+
+    await waitFor(() => {
+      expect(mockGetAttestationsByAttesterWithMetadata).toHaveBeenCalledWith(WALLET_ADDRESS, 66238, 100)
+    })
+  })
+
+  it('shows empty state when no attestations found', async () => {
+    setupConnected()
+    mockGetAttestationsByAttesterWithMetadata.mockResolvedValue([])
+
+    render(<DashboardPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/no attestations found for this wallet/i)).toBeInTheDocument()
+    })
+  })
+
+  // ── Schema & recipient display ──────────────────────────────────────
+
+  it('displays schema title for each attestation', async () => {
+    setupConnected()
+    mockGetAttestationsByAttesterWithMetadata.mockResolvedValue([
+      makeAttestation({ schemaTitle: 'Key Binding' }),
+    ])
+
+    render(<DashboardPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Key Binding')).toBeInTheDocument()
+    })
+  })
+
+  it('displays "Unknown schema" when schemaTitle is missing', async () => {
+    setupConnected()
+    mockGetAttestationsByAttesterWithMetadata.mockResolvedValue([
+      makeAttestation({ schemaTitle: undefined, schemaId: undefined }),
+    ])
+
+    render(<DashboardPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Unknown schema')).toBeInTheDocument()
+    })
+  })
+
+  it('uses decodedData.subject as recipient label when available', async () => {
+    setupConnected()
+    mockGetAttestationsByAttesterWithMetadata.mockResolvedValue([
+      makeAttestation({ decodedData: { subject: 'did:web:example.com' } }),
+    ])
+
+    render(<DashboardPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/did:web:example\.com/)).toBeInTheDocument()
+    })
+  })
+
+  it('falls back to recipient address when decodedData.subject is absent', async () => {
+    setupConnected()
+    mockGetAttestationsByAttesterWithMetadata.mockResolvedValue([
+      makeAttestation({ decodedData: undefined, recipient: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' }),
+    ])
+
+    render(<DashboardPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/0xabcdefabcd.*abcd/)).toBeInTheDocument()
+    })
+  })
+
+  // ── Revocation status badges ────────────────────────────────────────
+
+  it('shows "Active" badge when revocationTime is 0', async () => {
+    setupConnected()
+    mockGetAttestationsByAttesterWithMetadata.mockResolvedValue([
+      makeAttestation({ revocationTime: 0 }),
+    ])
+
+    render(<DashboardPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Active')).toBeInTheDocument()
+    })
+  })
+
+  it('shows "Revoked" badge when revocationTime > 0', async () => {
+    setupConnected()
+    mockGetAttestationsByAttesterWithMetadata.mockResolvedValue([
+      makeAttestation({ revocationTime: 1700000000 }),
+    ])
+
+    render(<DashboardPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Revoked')).toBeInTheDocument()
+    })
+  })
+
+  // ── Revoke button visibility ────────────────────────────────────────
+
+  it('shows Revoke button for revocable attestation with matching attester', async () => {
+    setupConnected()
+    mockGetAttestationsByAttesterWithMetadata.mockResolvedValue([
+      makeAttestation({ revocable: true, revocationTime: 0, attester: WALLET_ADDRESS }),
+    ])
+
+    render(<DashboardPage />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Revoke' })).toBeInTheDocument()
+    })
+  })
+
+  it('does not show Revoke button for non-revocable attestation', async () => {
+    setupConnected()
+    mockGetAttestationsByAttesterWithMetadata.mockResolvedValue([
+      makeAttestation({ revocable: false, revocationTime: 0 }),
+    ])
+
+    render(<DashboardPage />)
+
+    await waitFor(() => {
+      expect(mockGetAttestationsByAttesterWithMetadata).toHaveBeenCalled()
+    })
+
+    expect(screen.queryByRole('button', { name: 'Revoke' })).not.toBeInTheDocument()
+  })
+
+  it('does not show Revoke button for already revoked attestation', async () => {
+    setupConnected()
+    mockGetAttestationsByAttesterWithMetadata.mockResolvedValue([
+      makeAttestation({ revocable: true, revocationTime: 1700000000 }),
+    ])
+
+    render(<DashboardPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Revoked')).toBeInTheDocument()
+    })
+
+    expect(screen.queryByRole('button', { name: 'Revoke' })).not.toBeInTheDocument()
+  })
+
+  it('does not show Revoke button when attester does not match connected wallet', async () => {
+    setupConnected()
+    mockGetAttestationsByAttesterWithMetadata.mockResolvedValue([
+      makeAttestation({ revocable: true, revocationTime: 0, attester: OTHER_ADDRESS }),
+    ])
+
+    render(<DashboardPage />)
+
+    await waitFor(() => {
+      expect(mockGetAttestationsByAttesterWithMetadata).toHaveBeenCalled()
+    })
+
+    expect(screen.queryByRole('button', { name: 'Revoke' })).not.toBeInTheDocument()
+  })
+
+  // ── Revoke confirmation dialog flow ─────────────────────────────────
+
+  it('opens confirmation dialog when Revoke button is clicked', async () => {
+    setupConnected()
+    mockGetAttestationsByAttesterWithMetadata.mockResolvedValue([
+      makeAttestation({ revocable: true, revocationTime: 0, attester: WALLET_ADDRESS }),
+    ])
+
+    render(<DashboardPage />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Revoke' })).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Revoke' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Revoke Attestation')).toBeInTheDocument()
+      expect(screen.getByText(/this will permanently revoke attestation/i)).toBeInTheDocument()
+    })
+  })
+
+  it('closes confirmation dialog when Cancel is clicked', async () => {
+    setupConnected()
+    mockGetAttestationsByAttesterWithMetadata.mockResolvedValue([
+      makeAttestation({ revocable: true, revocationTime: 0, attester: WALLET_ADDRESS }),
+    ])
+
+    render(<DashboardPage />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Revoke' })).toBeInTheDocument()
+    })
+
+    // Open dialog
+    fireEvent.click(screen.getByRole('button', { name: 'Revoke' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Revoke Attestation')).toBeInTheDocument()
+    })
+
+    // Cancel
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+
+    await waitFor(() => {
+      expect(screen.queryByText('Revoke Attestation')).not.toBeInTheDocument()
+    })
+  })
+
+  // ── Error handling ──────────────────────────────────────────────────
+
+  it('shows error message when attestation loading fails', async () => {
+    setupConnected()
+    mockGetAttestationsByAttesterWithMetadata.mockRejectedValue(new Error('Network error'))
+
+    render(<DashboardPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Network error')).toBeInTheDocument()
+    })
+  })
+
+  // ── Loading state ───────────────────────────────────────────────────
+
+  it('shows loading state while fetching attestations', async () => {
+    setupConnected()
+    // Never resolves
+    mockGetAttestationsByAttesterWithMetadata.mockImplementation(() => new Promise(() => {}))
+
+    render(<DashboardPage />)
+
+    expect(screen.getByText(/loading attestations/i)).toBeInTheDocument()
+  })
+
+  // ── Refresh button ──────────────────────────────────────────────────
+
+  it('reloads attestations when Refresh button is clicked', async () => {
+    setupConnected()
+    mockGetAttestationsByAttesterWithMetadata.mockResolvedValue([])
+
+    render(<DashboardPage />)
+
+    await waitFor(() => {
+      expect(mockGetAttestationsByAttesterWithMetadata).toHaveBeenCalledTimes(1)
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /refresh/i }))
+
+    await waitFor(() => {
+      expect(mockGetAttestationsByAttesterWithMetadata).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  // ── Multiple attestations with mixed states ─────────────────────────
+
+  it('renders multiple attestations with correct revoke visibility', async () => {
+    setupConnected()
+    mockGetAttestationsByAttesterWithMetadata.mockResolvedValue([
+      makeAttestation({
+        uid: '0x' + 'a'.repeat(64),
+        revocable: true,
+        revocationTime: 0,
+        attester: WALLET_ADDRESS,
+        schemaTitle: 'Key Binding',
+      }),
+      makeAttestation({
+        uid: '0x' + 'b'.repeat(64),
+        revocable: false,
+        revocationTime: 0,
+        schemaTitle: 'Certification',
+      }),
+      makeAttestation({
+        uid: '0x' + 'c'.repeat(64),
+        revocable: true,
+        revocationTime: 1700000000,
+        schemaTitle: 'Linked Identifier',
+      }),
+    ])
+
+    render(<DashboardPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Key Binding')).toBeInTheDocument()
+      expect(screen.getByText('Certification')).toBeInTheDocument()
+      expect(screen.getByText('Linked Identifier')).toBeInTheDocument()
+    })
+
+    // Only the first attestation (revocable + active + matching attester) gets a Revoke button
+    const revokeButtons = screen.getAllByRole('button', { name: 'Revoke' })
+    expect(revokeButtons).toHaveLength(1)
+
+    // Should show both Active and Revoked badges
+    expect(screen.getAllByText('Active')).toHaveLength(2)
+    expect(screen.getByText('Revoked')).toBeInTheDocument()
+  })
+
+  // ── Revoke execution flow ───────────────────────────────────────────
+
+  it('calls revokeAttestation and refreshes list on successful revocation', async () => {
+    setupConnected()
+    mockRevokeAttestation.mockResolvedValue(undefined)
+    mockGetAttestationsByAttesterWithMetadata
+      .mockResolvedValueOnce([makeAttestation({ revocable: true, revocationTime: 0, attester: WALLET_ADDRESS })])
+      // After revoke, return revoked version
+      .mockResolvedValueOnce([makeAttestation({ revocable: true, revocationTime: 1700000000, attester: WALLET_ADDRESS })])
+
+    render(<DashboardPage />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Revoke' })).toBeInTheDocument()
+    })
+
+    // Click Revoke to open dialog
+    fireEvent.click(screen.getByRole('button', { name: 'Revoke' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Revoke Attestation')).toBeInTheDocument()
+    })
+
+    // Confirm revocation in dialog
+    fireEvent.click(screen.getByRole('button', { name: 'Revoke' }))
+
+    await waitFor(() => {
+      expect(mockRevokeAttestation).toHaveBeenCalledTimes(1)
+    })
+
+    // Should refresh attestations after revocation
+    await waitFor(() => {
+      expect(mockGetAttestationsByAttesterWithMetadata).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  it('shows error when revocation fails', async () => {
+    setupConnected()
+    mockRevokeAttestation.mockRejectedValue(new Error('User rejected transaction'))
+    mockGetAttestationsByAttesterWithMetadata.mockResolvedValue([
+      makeAttestation({ revocable: true, revocationTime: 0, attester: WALLET_ADDRESS }),
+    ])
+
+    render(<DashboardPage />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Revoke' })).toBeInTheDocument()
+    })
+
+    // Open dialog and confirm
+    fireEvent.click(screen.getByRole('button', { name: 'Revoke' }))
+    await waitFor(() => {
+      expect(screen.getByText('Revoke Attestation')).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Revoke' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('User rejected transaction')).toBeInTheDocument()
+    })
+  })
+
+  // ── Detail modal ────────────────────────────────────────────────────
+
+  it('opens detail modal when attestation row is clicked', async () => {
+    setupConnected()
+    mockGetAttestationsByAttesterWithMetadata.mockResolvedValue([
+      makeAttestation({ schemaTitle: 'Linked Identifier' }),
+    ])
+
+    render(<DashboardPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Linked Identifier')).toBeInTheDocument()
+    })
+
+    // Click the row (not the revoke button)
+    fireEvent.click(screen.getByText('Linked Identifier'))
+
+    await waitFor(() => {
+      expect(screen.getByText(/UID:/i)).toBeInTheDocument()
+    })
+  })
+
+  it('closes detail modal when close button is clicked', async () => {
+    setupConnected()
+    mockGetAttestationsByAttesterWithMetadata.mockResolvedValue([
+      makeAttestation({ schemaTitle: 'Key Binding' }),
+    ])
+
+    render(<DashboardPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Key Binding')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText('Key Binding'))
+
+    await waitFor(() => {
+      expect(screen.getByText(/UID:/i)).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /close/i }))
+
+    await waitFor(() => {
+      expect(screen.queryByText(/UID:/i)).not.toBeInTheDocument()
+    })
+  })
+
+  // ── Block explorer link ─────────────────────────────────────────────
+
+  it('renders block explorer link when txHash is present', async () => {
+    setupConnected()
+    mockGetAttestationsByAttesterWithMetadata.mockResolvedValue([
+      makeAttestation({
+        txHash: '0xdeadbeef1234567890abcdef1234567890abcdef1234567890abcdef12345678',
+      }),
+    ])
+
+    render(<DashboardPage />)
+
+    await waitFor(() => {
+      const link = screen.getByTitle('View transaction')
+      expect(link).toBeInTheDocument()
+      expect(link).toHaveAttribute(
+        'href',
+        'https://explorer.testnet.chain.oma3.org/tx/0xdeadbeef1234567890abcdef1234567890abcdef1234567890abcdef12345678'
+      )
+      expect(link).toHaveAttribute('target', '_blank')
+    })
+  })
+
+  it('does not render block explorer link when txHash is absent', async () => {
+    setupConnected()
+    mockGetAttestationsByAttesterWithMetadata.mockResolvedValue([
+      makeAttestation({ txHash: undefined }),
+    ])
+
+    render(<DashboardPage />)
+
+    await waitFor(() => {
+      expect(mockGetAttestationsByAttesterWithMetadata).toHaveBeenCalled()
+    })
+
+    expect(screen.queryByTitle('View transaction')).not.toBeInTheDocument()
+  })
+
+  // ── EAS not available ───────────────────────────────────────────────
+
+  it('shows EAS unavailable message when contract address is missing', async () => {
+    mockGetContractAddress.mockReturnValue(undefined)
+    setupConnected()
+
+    render(<DashboardPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/currently available only on EAS-enabled chains/i)).toBeInTheDocument()
+    })
   })
 })

--- a/tests/components/FieldRenderer.test.tsx
+++ b/tests/components/FieldRenderer.test.tsx
@@ -92,15 +92,36 @@ describe('FieldRenderer', () => {
     expect(input).toHaveValue('https://example.com');
   });
 
-  it('renders an enum select with options', () => {
+  it('renders enum as radio buttons when ≤7 options', () => {
+    const handleChange = vi.fn();
     render(
-      <FieldRenderer field={{ ...baseField, type: 'enum', options: ['A', 'B', 'C'] }} value="B" onChange={() => {}} />
+      <FieldRenderer field={{ ...baseField, type: 'enum', options: ['A', 'B', 'C'] }} value="B" onChange={handleChange} />
+    );
+    const radios = screen.getAllByRole('radio');
+    expect(radios).toHaveLength(3);
+    // B should be checked
+    expect(radios[1]).toBeChecked();
+    expect(radios[0]).not.toBeChecked();
+    expect(radios[2]).not.toBeChecked();
+    // Labels rendered
+    expect(screen.getByText('A')).toBeInTheDocument();
+    expect(screen.getByText('B')).toBeInTheDocument();
+    expect(screen.getByText('C')).toBeInTheDocument();
+    // Clicking a radio triggers onChange
+    fireEvent.click(radios[2]);
+    expect(handleChange).toHaveBeenCalledWith('C');
+  });
+
+  it('renders enum as select dropdown when >7 options', () => {
+    const manyOptions = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'];
+    render(
+      <FieldRenderer field={{ ...baseField, type: 'enum', options: manyOptions }} value="C" onChange={() => {}} />
     );
     const select = screen.getByLabelText(/Test Field/i);
     expect(select.tagName).toBe('SELECT');
-    expect(select).toHaveValue('B');
+    expect(select).toHaveValue('C');
     const options = screen.getAllByRole('option');
-    expect(options).toHaveLength(4); // 1 placeholder + 3 options
+    expect(options).toHaveLength(9); // 1 placeholder + 8 options
     expect(options[0]).toHaveTextContent(/select test field/i);
   });
 
@@ -115,16 +136,43 @@ describe('FieldRenderer', () => {
     expect(options).toHaveLength(1); // Only placeholder
   });
 
-  it('renders an array input and allows adding/removing items', async () => {
+  it('renders array as checkboxes when options provided (≤7)', () => {
     const handleChange = vi.fn();
     render(
       <FieldRenderer field={{ ...baseField, type: 'array', options: ['X', 'Y', 'Z'] }} value={['X']} onChange={handleChange} />
     );
+    const checkboxes = screen.getAllByRole('checkbox');
+    expect(checkboxes).toHaveLength(3);
+    // X should be checked
+    expect(checkboxes[0]).toBeChecked();
+    expect(checkboxes[1]).not.toBeChecked();
+    expect(checkboxes[2]).not.toBeChecked();
+    // Toggle Y on
+    fireEvent.click(checkboxes[1]);
+    expect(handleChange).toHaveBeenCalledWith(['X', 'Y']);
+  });
+
+  it('renders array as checkboxes and allows unchecking', () => {
+    const handleChange = vi.fn();
+    render(
+      <FieldRenderer field={{ ...baseField, type: 'array', options: ['X', 'Y', 'Z'] }} value={['X', 'Z']} onChange={handleChange} />
+    );
+    const checkboxes = screen.getAllByRole('checkbox');
+    // Uncheck X
+    fireEvent.click(checkboxes[0]);
+    expect(handleChange).toHaveBeenCalledWith(['Z']);
+  });
+
+  it('renders array free-text input when no options provided', async () => {
+    const handleChange = vi.fn();
+    render(
+      <FieldRenderer field={{ ...baseField, type: 'array' }} value={['A']} onChange={handleChange} />
+    );
     const input = screen.getByPlaceholderText(/add item/i);
-    await userEvent.type(input, 'Y');
+    await userEvent.type(input, 'B');
     fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
     await waitFor(() => {
-      expect(handleChange).toHaveBeenCalledWith(['X', 'Y']);
+      expect(handleChange).toHaveBeenCalledWith(['A', 'B']);
     });
     // Remove item
     const removeBtn = screen.getByRole('button', { name: /remove/i });

--- a/tests/components/header.test.tsx
+++ b/tests/components/header.test.tsx
@@ -34,6 +34,15 @@ describe('Header', () => {
     expect(screen.getByText('Docs')).not.toBeNull();
   });
 
+  it('renders My Attestations nav link pointing to /dashboard', async () => {
+    await act(async () => {
+      render(<Header />);
+    });
+    const link = screen.getByText('My Attestations');
+    expect(link).not.toBeNull();
+    expect(link.closest('a')).toHaveAttribute('href', '/dashboard');
+  });
+
   it('renders wallet connect button', async () => {
     await act(async () => {
       render(<Header />);

--- a/tests/components/revoke-confirmation-dialog.test.tsx
+++ b/tests/components/revoke-confirmation-dialog.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { RevokeConfirmationDialog } from '@/components/revoke-confirmation-dialog'
+
+describe('RevokeConfirmationDialog', () => {
+  const defaultProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+    onConfirm: vi.fn(),
+    attestationUid: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    isRevoking: false,
+  }
+
+  it('renders dialog content when open', () => {
+    render(<RevokeConfirmationDialog {...defaultProps} />)
+    expect(screen.getByText('Revoke Attestation')).toBeInTheDocument()
+    expect(screen.getByText(/this will permanently revoke attestation/i)).toBeInTheDocument()
+    expect(screen.getByText(/this action cannot be undone/i)).toBeInTheDocument()
+  })
+
+  it('does not render dialog content when closed', () => {
+    render(<RevokeConfirmationDialog {...defaultProps} isOpen={false} />)
+    expect(screen.queryByText('Revoke Attestation')).not.toBeInTheDocument()
+  })
+
+  it('displays truncated UID for long UIDs', () => {
+    render(<RevokeConfirmationDialog {...defaultProps} />)
+    // UID is 66 chars, should be truncated to first 10 + ... + last 6
+    expect(screen.getByText('0xaaaaaaaa...aaaaaa')).toBeInTheDocument()
+  })
+
+  it('displays short UID as-is without truncation', () => {
+    render(<RevokeConfirmationDialog {...defaultProps} attestationUid="0x1234" />)
+    expect(screen.getByText('0x1234')).toBeInTheDocument()
+  })
+
+  it('calls onConfirm when Revoke button is clicked', () => {
+    const onConfirm = vi.fn()
+    render(<RevokeConfirmationDialog {...defaultProps} onConfirm={onConfirm} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Revoke' }))
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onClose when Cancel button is clicked', () => {
+    const onClose = vi.fn()
+    render(<RevokeConfirmationDialog {...defaultProps} onClose={onClose} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('shows "Revoking..." text and disables buttons while revoking', () => {
+    render(<RevokeConfirmationDialog {...defaultProps} isRevoking={true} />)
+    expect(screen.getByRole('button', { name: 'Revoking...' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled()
+  })
+
+  it('shows "Revoke" text when not revoking', () => {
+    render(<RevokeConfirmationDialog {...defaultProps} isRevoking={false} />)
+    expect(screen.getByRole('button', { name: 'Revoke' })).not.toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Cancel' })).not.toBeDisabled()
+  })
+})

--- a/tests/lib/attestation-queries.test.ts
+++ b/tests/lib/attestation-queries.test.ts
@@ -5,6 +5,7 @@ import * as chains from '@/config/chains';
 import {
   getAttestationsForDIDWithMetadata,
   getLatestAttestationsWithMetadata,
+  getAttestationsByAttesterWithMetadata,
   type EnrichedAttestationResult,
 } from '@/lib/attestation-queries';
 
@@ -22,6 +23,7 @@ vi.mock('@oma3/omatrust/reputation', () => ({
   getAttestation: vi.fn().mockRejectedValue(new Error('not found')),
   getAttestationsForDid: vi.fn().mockResolvedValue([]),
   getLatestAttestations: vi.fn().mockResolvedValue([]),
+  getAttestationsByAttester: vi.fn().mockResolvedValue([]),
 }));
 
 vi.mock('@oma3/omatrust/identity', () => ({
@@ -69,10 +71,40 @@ describe('attestation-queries', () => {
     it('returns empty array when no schemas are deployed on chain', async () => {
       vi.mocked(getContractAddress).mockReturnValue('0x' + '1'.repeat(40));
       vi.spyOn(chains, 'getChainById').mockReturnValue({ id: 66238, rpc: 'https://rpc.testnet.chain.oma3.org/' } as any);
-      vi.spyOn(schemas, 'getAllSchemas').mockReturnValue([]);
+      const getAllSchemasSpy = vi.spyOn(schemas, 'getAllSchemas').mockReturnValue([]);
       const result = await getLatestAttestationsWithMetadata(66238);
       expect(result).toEqual([]);
-      vi.restoreAllMocks();
+      getAllSchemasSpy.mockRestore();
+    });
+  });
+
+  describe('getAttestationsByAttesterWithMetadata', () => {
+    beforeEach(() => {
+      vi.mocked(getContractAddress).mockReset();
+    });
+
+    it('throws when EAS is not deployed on chain', async () => {
+      vi.mocked(getContractAddress).mockReturnValue(null as unknown as string);
+      vi.spyOn(chains, 'getChainById').mockReturnValue(undefined);
+      await expect(
+        getAttestationsByAttesterWithMetadata('0x' + '1'.repeat(40), 999)
+      ).rejects.toThrow(/EAS not deployed|Unknown chain/i);
+    });
+
+    it('returns empty array when no schemas are deployed on chain', async () => {
+      vi.mocked(getContractAddress).mockReturnValue('0x' + '1'.repeat(40));
+      vi.spyOn(chains, 'getChainById').mockReturnValue({ id: 66238, rpc: 'https://rpc.testnet.chain.oma3.org/' } as any);
+      const getAllSchemasSpy = vi.spyOn(schemas, 'getAllSchemas').mockReturnValue([]);
+      const result = await getAttestationsByAttesterWithMetadata('0x' + '1'.repeat(40), 66238);
+      expect(result).toEqual([]);
+      getAllSchemasSpy.mockRestore();
+    });
+
+    it('returns empty array when SDK returns no results', async () => {
+      vi.mocked(getContractAddress).mockReturnValue('0x' + '1'.repeat(40));
+      vi.spyOn(chains, 'getChainById').mockReturnValue({ id: 66238, rpc: 'https://rpc.testnet.chain.oma3.org/' } as any);
+      const result = await getAttestationsByAttesterWithMetadata('0x' + '1'.repeat(40), 66238);
+      expect(result).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
## Summary
- **Fixes 2 failing FieldRenderer tests** — component changed enum (≤7 options) to radio buttons and array (with options ≤7) to checkboxes; tests updated to match
- **Adds 28 dashboard page tests** covering the full My Attestations page: disconnected prompt, table rendering, schema/recipient display, Active/Revoked badges, Revoke button visibility (revocable, non-revocable, already revoked, non-matching attester), confirmation dialog open/close, revoke execution success & failure, detail modal open/close, block explorer link, refresh, loading, error, and EAS-unavailable states
- **Adds 8 RevokeConfirmationDialog tests** covering open/closed state, UID truncation, Cancel/Revoke button callbacks, and loading state
- **Adds 3 getAttestationsByAttesterWithMetadata query tests** for EAS-not-deployed, no-schemas, and empty-results scenarios
- **Adds 1 header nav test** verifying the "My Attestations" link is visible and points to `/dashboard`

**Result: 68 test files, 833 tests — all passing, 0 failures**

Dashboard page coverage: 79% → 96%

## Test plan
- [x] All 833 tests pass (`npx vitest run`)
- [x] No regressions in existing test files
- [x] New `revoke-confirmation-dialog.test.tsx` file at 100% coverage
- [x] Dashboard page coverage improved from 79.42% to 96.29%
- [x] Previously failing FieldRenderer tests now pass with updated assertions