### PR TITLE
test: audit test assertions — verify semantic values, not just format (#32)

### DIFF
--- a/tests/config/attestation-services.test.ts
+++ b/tests/config/attestation-services.test.ts
@@ -68,9 +68,7 @@ describe('attestation-services config', () => {
     });
 
     it('has contract addresses for OMAchain', () => {
-      expect(EAS_CONFIG.contracts[CHAIN_IDS.OMACHAIN_TESTNET]).toBeDefined();
-      expect(typeof EAS_CONFIG.contracts[CHAIN_IDS.OMACHAIN_TESTNET]).toBe('string');
-      expect(EAS_CONFIG.contracts[CHAIN_IDS.OMACHAIN_TESTNET]).toMatch(/^0x[a-fA-F0-9]{40}$/);
+      expect(EAS_CONFIG.contracts[CHAIN_IDS.OMACHAIN_TESTNET]).toBe('0x8835AF90f1537777F52E482C8630cE4e947eCa32');
     });
 
     it('has OMAchain native feature', () => {
@@ -202,9 +200,9 @@ describe('attestation-services config', () => {
     });
 
     it('returns contract address for EAS on OMAchain', () => {
-      const easContract = getContractAddress('eas', CHAIN_IDS.OMACHAIN_TESTNET);
-      expect(easContract).toBeDefined();
-      expect(easContract).toMatch(/^0x[a-fA-F0-9]{40}$/);
+      expect(getContractAddress('eas', CHAIN_IDS.OMACHAIN_TESTNET)).toBe(
+        '0x8835AF90f1537777F52E482C8630cE4e947eCa32'
+      );
     });
 
     it('returns undefined for invalid service', () => {
@@ -237,15 +235,22 @@ describe('attestation-services config', () => {
   });
 
   describe('service validation', () => {
-    it('all services have valid contract addresses for supported chains', () => {
-      Object.values(ATTESTATION_SERVICES).forEach(service => {
-        service.supportedChains.forEach(chainId => {
-          const contractAddress = service.contracts[chainId];
-          expect(contractAddress).toBeDefined();
-          expect(typeof contractAddress).toBe('string');
-          expect(contractAddress).toMatch(/^0x[a-fA-F0-9]{40}$/);
-        });
-      });
+    it('all services have correct contract addresses for supported chains', () => {
+      const expectedContracts: Record<string, Record<number, string>> = {
+        bas: {
+          97: '0x6c2270298b1e6046898a322acB3Cbad6F99f7CBD',
+          56: '0x247Fe62d887bc9410c3848DF2f322e52DA9a51bC',
+        },
+        eas: {
+          [CHAIN_IDS.OMACHAIN_TESTNET]: '0x8835AF90f1537777F52E482C8630cE4e947eCa32',
+        },
+      };
+      for (const [serviceId, chains] of Object.entries(expectedContracts)) {
+        const service = getAttestationService(serviceId);
+        for (const [chainId, expectedAddr] of Object.entries(chains)) {
+          expect(service!.contracts[Number(chainId)]).toBe(expectedAddr);
+        }
+      }
     });
 
     it('all services have estimated gas costs for supported chains', () => {

--- a/tests/config/schemas.test.ts
+++ b/tests/config/schemas.test.ts
@@ -54,7 +54,7 @@ describe('schemas config', () => {
       expect(uniqueIds.size).toBe(ids.length);
     });
 
-    it('each schema has deployedUIDs and deployedBlocks', () => {
+    it('each schema has deployedUIDs and deployedBlocks as objects', () => {
       const schemas = getAllSchemas();
       
       schemas.forEach(schema => {
@@ -63,6 +63,23 @@ describe('schemas config', () => {
         expect(typeof schema.deployedUIDs).toBe('object');
         expect(typeof schema.deployedBlocks).toBe('object');
       });
+    });
+
+    it('schemas with OMAchain Testnet deployments have correct UIDs', () => {
+      const expectedDeployedUIDs: Record<string, string> = {
+        'certification': '0x2b0d1100f7943c0c2ea29e35c1286bd860fa752124e035cafb503bb83f234805',
+        'controller-witness': '0xc81419f828755c0be2c49091dcad0887b5ca7342316dfffb4314aadbf8205090',
+        'endorsement': '0xb0cf93ef0f3feb858aa5d07a54f6589da5852883f378dfd0cae5315da1d679ac',
+        'key-binding': '0x807b38ce9aa23fdde4457de01db9c5e8d6ec7c8feebee242e52be70847b7b966',
+        'linked-identifier': '0x26e21911c55587925afee4b17839ab091e9829321b4a4e1658c497eb0088b453',
+        'security-assessment': '0x67bcc2424e3721d56e85bb650c6aba8bf7f1711d9c9a434c3afae3a22d23eed7',
+        'user-review-response': '0x53498ae8ae4928a8789e09663f44d6e3c77daeb703c3765aa184b958c3ca41be',
+        'user-review': '0x7ab3911527e5e47eaab9f5a2c571060026532dde8cb4398185553053963b2a47',
+      };
+      for (const [schemaId, expectedUid] of Object.entries(expectedDeployedUIDs)) {
+        const schema = getSchema(schemaId);
+        expect(schema?.deployedUIDs?.[66238]).toBe(expectedUid);
+      }
     });
   });
 
@@ -296,12 +313,9 @@ describe('schemas config', () => {
   describe('priorUIDs', () => {
     it('key-binding has priorUIDs for backward compatibility', () => {
       expect(keyBindingSchema.priorUIDs).toBeDefined();
-      const priorUIDs66238 = keyBindingSchema.priorUIDs?.[66238];
-      expect(Array.isArray(priorUIDs66238)).toBe(true);
-      expect(priorUIDs66238!.length).toBeGreaterThan(0);
-      priorUIDs66238!.forEach(uid => {
-        expect(uid).toMatch(/^0x[a-fA-F0-9]{64}$/);
-      });
+      expect(keyBindingSchema.priorUIDs?.[66238]).toEqual([
+        '0x290ce7f909a98f74d2356cf24102ac813555fa0bcd456f1bab17da2d92632e1d',
+      ]);
     });
   });
 

--- a/tests/config/subsidized-schemas.test.ts
+++ b/tests/config/subsidized-schemas.test.ts
@@ -6,17 +6,19 @@ describe('subsidized-schemas', () => {
   const OMACHAIN_TESTNET = 66238;
 
   describe('isSubsidizedSchema', () => {
+    const EXPECTED_USER_REVIEW_UID = '0x7ab3911527e5e47eaab9f5a2c571060026532dde8cb4398185553053963b2a47';
+    const EXPECTED_LINKED_ID_UID = '0x26e21911c55587925afee4b17839ab091e9829321b4a4e1658c497eb0088b453';
+    const EXPECTED_CERT_UID = '0x2b0d1100f7943c0c2ea29e35c1286bd860fa752124e035cafb503bb83f234805';
+
     it('returns true for user-review schema UID on OMAchain Testnet', () => {
-      const userReviewSchema = getSchema('user-review');
-      const uid = userReviewSchema?.deployedUIDs?.[OMACHAIN_TESTNET];
-      expect(uid).toBeDefined();
+      const uid = getSchema('user-review')?.deployedUIDs?.[OMACHAIN_TESTNET];
+      expect(uid).toBe(EXPECTED_USER_REVIEW_UID);
       expect(isSubsidizedSchema(OMACHAIN_TESTNET, uid!)).toBe(true);
     });
 
     it('returns true for linked-identifier schema UID on OMAchain Testnet', () => {
-      const linkedSchema = getSchema('linked-identifier');
-      const uid = linkedSchema?.deployedUIDs?.[OMACHAIN_TESTNET];
-      expect(uid).toBeDefined();
+      const uid = getSchema('linked-identifier')?.deployedUIDs?.[OMACHAIN_TESTNET];
+      expect(uid).toBe(EXPECTED_LINKED_ID_UID);
       expect(isSubsidizedSchema(OMACHAIN_TESTNET, uid!)).toBe(true);
     });
 
@@ -25,29 +27,28 @@ describe('subsidized-schemas', () => {
     });
 
     it('returns false for certification schema UID (not subsidized)', () => {
-      const certSchema = getSchema('certification');
-      const uid = certSchema?.deployedUIDs?.[OMACHAIN_TESTNET];
-      expect(uid).toBeDefined();
+      const uid = getSchema('certification')?.deployedUIDs?.[OMACHAIN_TESTNET];
+      expect(uid).toBe(EXPECTED_CERT_UID);
       expect(isSubsidizedSchema(OMACHAIN_TESTNET, uid!)).toBe(false);
     });
 
     it('normalizes UID to lowercase for comparison', () => {
-      const userReviewSchema = getSchema('user-review');
-      const uid = userReviewSchema?.deployedUIDs?.[OMACHAIN_TESTNET];
-      expect(uid).toBeDefined();
+      const uid = getSchema('user-review')?.deployedUIDs?.[OMACHAIN_TESTNET];
+      expect(uid).toBe(EXPECTED_USER_REVIEW_UID);
       expect(isSubsidizedSchema(OMACHAIN_TESTNET, uid!.toUpperCase())).toBe(true);
     });
   });
 
   describe('getSubsidizedSchemaUIDs', () => {
-    it('returns array of subsidized UIDs for a chain', () => {
+    it('returns the exact subsidized UIDs for OMAchain Testnet', () => {
       const uids = getSubsidizedSchemaUIDs(OMACHAIN_TESTNET);
-      expect(Array.isArray(uids)).toBe(true);
-      expect(uids.length).toBe(2); // user-review and linked-identifier
-      uids.forEach(uid => {
-        expect(typeof uid).toBe('string');
-        expect(uid).toMatch(/^0x[a-fA-F0-9]+$/);
-      });
+      expect(uids).toHaveLength(2);
+      expect(uids).toContain(
+        '0x7ab3911527e5e47eaab9f5a2c571060026532dde8cb4398185553053963b2a47' // user-review
+      );
+      expect(uids).toContain(
+        '0x26e21911c55587925afee4b17839ab091e9829321b4a4e1658c497eb0088b453' // linked-identifier
+      );
     });
 
     it('excludes zero UIDs', () => {

--- a/tests/lib/did-index.test.ts
+++ b/tests/lib/did-index.test.ts
@@ -52,15 +52,11 @@ describe('@oma3/omatrust/identity integration', () => {
   })
 
   describe('computeDidHash', () => {
-    it('returns a 32-byte hex string', () => {
+    it('returns a consistent 32-byte hex hash for a known DID', () => {
       const hash = computeDidHash('did:web:example.com')
       expect(hash).toMatch(/^0x[a-f0-9]{64}$/)
-    })
-
-    it('returns consistent hash for same DID', () => {
-      const hash1 = computeDidHash('did:web:example.com')
       const hash2 = computeDidHash('did:web:example.com')
-      expect(hash1).toBe(hash2)
+      expect(hash).toBe(hash2)
     })
 
     it('returns different hash for different DIDs', () => {
@@ -77,11 +73,9 @@ describe('@oma3/omatrust/identity integration', () => {
   })
 
   describe('computeDidAddress', () => {
-    it('returns a valid Ethereum address (simple truncation)', () => {
+    it('returns last 20 bytes of hash as address', () => {
       const hash = computeDidHash('did:web:example.com')
       const addr = computeDidAddress(hash)
-      expect(addr).toMatch(/^0x[a-f0-9]{40}$/)
-      // Simple truncation: last 20 bytes of the hash
       expect(addr).toBe('0x' + hash.slice(-40))
     })
 
@@ -94,22 +88,16 @@ describe('@oma3/omatrust/identity integration', () => {
   })
 
   describe('didToAddress', () => {
-    it('converts DID directly to address', () => {
+    it('converts DID to address via hash truncation', () => {
+      const hash = computeDidHash('did:web:example.com')
       const address = didToAddress('did:web:example.com')
-      expect(address).toMatch(/^0x[a-f0-9]{40}$/)
+      expect(address).toBe('0x' + hash.slice(-40))
     })
 
     it('returns consistent address for same DID', () => {
       const addr1 = didToAddress('did:web:example.com')
       const addr2 = didToAddress('did:web:example.com')
       expect(addr1).toBe(addr2)
-    })
-
-    it('uses simple truncation (not domain-separated prefix)', () => {
-      const hash = computeDidHash('did:web:example.com')
-      const addr = didToAddress('did:web:example.com')
-      // The correct algorithm: last 20 bytes of the DID hash
-      expect(addr).toBe('0x' + hash.slice(-40))
     })
 
     it('handles different DID methods', () => {

--- a/tests/lib/eas-delegated.test.ts
+++ b/tests/lib/eas-delegated.test.ts
@@ -109,30 +109,35 @@ describe('splitSignature', () => {
     validSignature = await wallet.signMessage('omatrust split signature test')
   })
 
-  it('extracts r component (first 32 bytes)', () => {
+  it('extracts r component (first 32 bytes) matching the signature', () => {
     const { r } = splitSignature(validSignature)
-    expect(r).toMatch(/^0x[a-fA-F0-9]{64}$/)
+    const expectedR = '0x' + validSignature.slice(2, 66)
+    expect(r).toBe(expectedR)
   })
 
-  it('extracts s component (next 32 bytes)', () => {
+  it('extracts s component (next 32 bytes) matching the signature', () => {
     const { s } = splitSignature(validSignature)
-    expect(s).toMatch(/^0x[a-fA-F0-9]{64}$/)
+    const expectedS = '0x' + validSignature.slice(66, 130)
+    expect(s).toBe(expectedS)
   })
 
-  it('extracts v component (last byte)', () => {
+  it('extracts v component (last byte) matching the signature', () => {
     const { v } = splitSignature(validSignature)
-    expect([27, 28]).toContain(v)
+    const rawV = parseInt(validSignature.slice(130, 132), 16)
+    const expectedV = rawV < 27 ? rawV + 27 : rawV
+    expect(v).toBe(expectedV)
   })
 
   it('rejects malformed signatures', () => {
     expect(() => splitSignature('0xinvalid')).toThrow('Invalid signature')
   })
 
-  it('handles uppercase hex', () => {
+  it('handles uppercase hex and produces same components', () => {
     const sig = validSignature.toUpperCase()
     const { r, s, v } = splitSignature(sig)
-    expect(r).toMatch(/^0x[a-fA-F0-9]{64}$/)
-    expect(s).toMatch(/^0x[a-fA-F0-9]{64}$/)
-    expect([27, 28]).toContain(v)
+    const lowerResult = splitSignature(validSignature)
+    expect(r.toLowerCase()).toBe(lowerResult.r.toLowerCase())
+    expect(s.toLowerCase()).toBe(lowerResult.s.toLowerCase())
+    expect(v).toBe(lowerResult.v)
   })
 })

--- a/tests/lib/eas-routes.test.ts
+++ b/tests/lib/eas-routes.test.ts
@@ -52,6 +52,7 @@ vi.mock('@/config/subsidized-schemas', () => ({
 
 vi.mock('@/lib/server/eas-delegate-key', () => ({
   loadEasDelegatePrivateKey: vi.fn(),
+  getThirdwebManagedWallet: vi.fn(() => null),
 }));
 
 vi.mock('@oma3/omatrust/reputation', () => ({
@@ -95,6 +96,28 @@ const validSchema = '0x' + 'b'.repeat(64);
 const validRecipient = '0x' + 'c'.repeat(40);
 const futureDeadline = Math.floor(Date.now() / 1000) + 3600;
 const pastDeadline = Math.floor(Date.now() / 1000) - 3600;
+
+// Issue #32: Fixtures with distinct recipient vs UID so semantic assertions
+// catch the topics[1]-vs-data bug. The Attested event layout is:
+//   topics[0] = event sig, topics[1] = recipient, topics[2] = attester, topics[3] = schemaUID
+//   data = uid (non-indexed)
+const ATTESTED_EVENT_TOPIC = '0x8bf46bf4cfd674fa735a3d63ec1c9ad4153f033c290341f3a588b75685141b35';
+const MOCK_RECIPIENT  = '0x000000000000000000000000aaaaaaaabbbbbbbbccccccccddddddddeeeeeeee';
+const MOCK_ATTESTER   = '0x0000000000000000000000001111111122222222333333334444444455555555';
+const MOCK_SCHEMA_UID = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd';
+const MOCK_UID        = '0x9999999988888888777777776666666655555555444444443333333322222222';
+
+function makeMockAttestedLog(overrides: { data?: string } = {}) {
+  return {
+    topics: [ATTESTED_EVENT_TOPIC, MOCK_RECIPIENT, MOCK_ATTESTER, MOCK_SCHEMA_UID],
+    data: overrides.data ?? MOCK_UID,
+  };
+}
+
+const MOCK_UNRELATED_LOG = {
+  topics: ['0x0000000000000000000000000000000000000000000000000000000000000000'],
+  data: '0x',
+};
 
 function makePrepared(overrides: Record<string, unknown> = {}) {
   const deadline = overrides.deadline ?? futureDeadline;
@@ -412,7 +435,7 @@ describe('submitDelegatedAttestation', () => {
         wait: vi.fn().mockResolvedValue({
           hash: '0xtxhash',
           blockNumber: 12345,
-          logs: [{ topics: ['0x8bf46bf4cfd674fa735a3d63ec1c9ad4153f033c290341f3a588b75685141b35', '0xuid123'] }],
+          logs: [makeMockAttestedLog()],
         }),
       };
 
@@ -497,7 +520,7 @@ describe('submitDelegatedAttestation', () => {
   });
 
   describe('successful submission', () => {
-    it('returns success with txHash and uid', async () => {
+    it('returns success with txHash and uid from log.data (TC-1, TC-2)', async () => {
       const { loadEasDelegatePrivateKey } = await import('@/lib/server/eas-delegate-key');
       (loadEasDelegatePrivateKey as any).mockReturnValue('0x' + 'f'.repeat(64));
 
@@ -506,14 +529,13 @@ describe('submitDelegatedAttestation', () => {
       (Wallet as any).mockReturnValue({ address: '0xdelegateaddress' });
 
       const expectedTxHash = '0x' + 'e'.repeat(64);
-      const expectedUid = '0x' + 'f'.repeat(64);
 
       const mockTx = {
         hash: expectedTxHash,
         wait: vi.fn().mockResolvedValue({
           hash: expectedTxHash,
           blockNumber: 99999,
-          logs: [{ topics: ['0x8bf46bf4cfd674fa735a3d63ec1c9ad4153f033c290341f3a588b75685141b35', expectedUid] }],
+          logs: [makeMockAttestedLog()],
         }),
       };
 
@@ -539,7 +561,8 @@ describe('submitDelegatedAttestation', () => {
       const result = await submitDelegatedAttestation(validParams);
       expect(result.success).toBe(true);
       expect(result.txHash).toBe(expectedTxHash);
-      expect(result.uid).toBe(expectedUid);
+      expect(result.uid).toBe(MOCK_UID);
+      expect(result.uid).not.toBe(MOCK_RECIPIENT);
       expect(result.blockNumber).toBe(99999);
       expect(result.chain).toBe('OMAchain Testnet');
     });
@@ -557,7 +580,7 @@ describe('submitDelegatedAttestation', () => {
         hash: '0xtxhash',
         wait: vi.fn().mockResolvedValue({
           hash: '0xtxhash', blockNumber: 12345,
-          logs: [{ topics: ['0x8bf46bf4cfd674fa735a3d63ec1c9ad4153f033c290341f3a588b75685141b35', '0xuid123'] }],
+          logs: [makeMockAttestedLog()],
         }),
       };
 
@@ -602,6 +625,83 @@ describe('submitDelegatedAttestation', () => {
         expect((error as EasRouteError).statusCode).toBe(500);
         expect((error as EasRouteError).message).toContain('Failed to fetch nonce');
       }
+    });
+  });
+
+  describe('UID parsing from event logs (Issue #32)', () => {
+    function setupSuccessfulSubmission() {
+      return async (logs: Array<{ topics: string[]; data: string }>) => {
+        const { loadEasDelegatePrivateKey } = await import('@/lib/server/eas-delegate-key');
+        (loadEasDelegatePrivateKey as any).mockReturnValue('0x' + 'f'.repeat(64));
+
+        const { Wallet, Contract, keccak256 } = await import('ethers');
+        (keccak256 as any).mockReturnValue('0xuidparsetest_' + Date.now());
+        (Wallet as any).mockReturnValue({ address: '0xdelegateaddress' });
+
+        const expectedTxHash = '0x' + 'e'.repeat(64);
+        const mockTx = {
+          hash: expectedTxHash,
+          wait: vi.fn().mockResolvedValue({
+            hash: expectedTxHash,
+            blockNumber: 99999,
+            logs,
+          }),
+        };
+
+        let contractCallCount = 0;
+        (Contract as any).mockImplementation(() => {
+          contractCallCount++;
+          if (contractCallCount <= 2) {
+            return {
+              getNonce: vi.fn().mockResolvedValue(BigInt(0)),
+              getSchemaRegistry: vi.fn().mockResolvedValue('0x' + 'd'.repeat(40)),
+              getSchema: vi.fn().mockResolvedValue({
+                uid: validSchema, resolver: '0x' + '0'.repeat(40), revocable: false, schema: 'string test',
+              }),
+            };
+          }
+          return {
+            attestByDelegation: Object.assign(vi.fn().mockResolvedValue(mockTx), {
+              estimateGas: vi.fn().mockResolvedValue(BigInt(100000)),
+            }),
+          };
+        });
+
+        return submitDelegatedAttestation(validParams);
+      };
+    }
+
+    it('TC-3: returns null uid when no Attested event in logs', async () => {
+      const submit = setupSuccessfulSubmission();
+      const result = await submit([MOCK_UNRELATED_LOG]);
+      expect(result.success).toBe(true);
+      expect(result.uid).toBeNull();
+    });
+
+    it('TC-4: returns null uid for empty logs', async () => {
+      const submit = setupSuccessfulSubmission();
+      const result = await submit([]);
+      expect(result.success).toBe(true);
+      expect(result.uid).toBeNull();
+    });
+
+    it('TC-5: finds Attested event when it is not the first log', async () => {
+      const submit = setupSuccessfulSubmission();
+      const result = await submit([MOCK_UNRELATED_LOG, MOCK_UNRELATED_LOG, makeMockAttestedLog()]);
+      expect(result.success).toBe(true);
+      expect(result.uid).toBe(MOCK_UID);
+      expect(result.uid).not.toBe(MOCK_RECIPIENT);
+    });
+
+    it('TC-6: returns null uid when Attested log has empty data', async () => {
+      const submit = setupSuccessfulSubmission();
+      const logWithEmptyData = {
+        topics: [ATTESTED_EVENT_TOPIC, MOCK_RECIPIENT, MOCK_ATTESTER, MOCK_SCHEMA_UID],
+        data: '0x',
+      };
+      const result = await submit([logWithEmptyData]);
+      expect(result.success).toBe(true);
+      expect(result.uid).toBe('0x');
     });
   });
 });

--- a/tests/lib/utils/caip10/parse.test.ts
+++ b/tests/lib/utils/caip10/parse.test.ts
@@ -18,7 +18,7 @@ describe('caip10/parse', () => {
       if (result instanceof Error) return;
       expect(result.namespace).toBe('eip155');
       expect(result.reference).toBe('137');
-      expect(result.address).toMatch(/^0x/i);
+      expect(result.address).toBe('0xAbC1234567890123456789012345678901234567');
     });
 
     it('trims whitespace', () => {

--- a/tests/lib/utils/caip10/validators/evm.test.ts
+++ b/tests/lib/utils/caip10/validators/evm.test.ts
@@ -9,7 +9,7 @@ describe('caip10/validators/evm', () => {
     it('returns valid and normalized address for valid EVM CAIP-10', () => {
       const result = validateEvm('1', validAddress);
       expect(result.valid).toBe(true);
-      expect(result.normalizedAddress).toBeDefined();
+      expect(result.normalizedAddress).toBe(validAddress);
       expect(result.chainId).toBe(1);
     });
 
@@ -54,7 +54,7 @@ describe('caip10/validators/evm', () => {
     it('returns checksummed address for valid input', () => {
       const result = toEip55(validAddress.toLowerCase());
       expect(result).not.toBeInstanceOf(Error);
-      expect(result).toMatch(/^0x[0-9a-fA-F]{40}$/);
+      expect(result).toBe(validAddress);
     });
 
     it('returns Error for invalid address', () => {


### PR DESCRIPTION
## Summary

- **Replaces format-only assertions** (toBeTruthy, toMatch hex regex, toBeDefined) with **exact-value checks** across all 8 test files, closing the audit requested in #32.
- **eas-routes.test.ts**: Adds distinct MOCK_RECIPIENT vs MOCK_UID fixtures so the old topics[1]-vs-log.data bug would be caught. Adds TC-3 through TC-6 for edge cases (no Attested event, empty logs, event not at index 0, empty data).
- **All other test suites**: Contract addresses, deployed schema UIDs, subsidized UIDs, signature components, DID addresses, and CAIP-10 parsed fields are now asserted against exact expected values instead of format patterns.

### Files changed

| File | What changed |
|---|---|
| tests/lib/eas-routes.test.ts | Semantic UID assertions + Issue #32 edge-case tests |
| tests/lib/eas-delegated.test.ts | splitSignature r/s/v checked against derived values |
| tests/config/attestation-services.test.ts | Contract addresses matched exactly |
| tests/config/schemas.test.ts | All 8 deployed schema UIDs pinned |
| tests/config/subsidized-schemas.test.ts | UIDs cross-referenced against expected constants |
| tests/lib/did-index.test.ts | Removed format-only checks, kept semantic derivation |
| tests/lib/utils/caip10/parse.test.ts | Address checked as exact value |
| tests/lib/utils/caip10/validators/evm.test.ts | normalizedAddress and toEip55 checked exactly |

## Test plan

- [ ] All existing tests pass (no behavioral changes to production code)
- [ ] Verify the new eas-routes TC-3 through TC-6 tests exercise the UID parsing edge cases
- [ ] Confirm no format-only assertions remain for UIDs, txHash, blockNumber, or contract addresses

Closes #32