### PR TITLE
fix(test): update semver validation assertion to match relaxed pattern

### DIFF
--- a/tests/components/AttestationForm.test.tsx
+++ b/tests/components/AttestationForm.test.tsx
@@ -384,8 +384,10 @@ describe('validateField function', () => {
   });
 
   it('validates pattern with semver subtype', () => {
-    const field = { name: 'version', label: 'Version', type: 'string', pattern: '^\\d+\\.\\d+\\.\\d+$', subtype: 'semver' };
+    const field = { name: 'version', label: 'Version', type: 'string', pattern: '^\\d+(\\.\\d+){0,2}$', subtype: 'semver' };
     expect(validateField(field, 'invalid')).toBe('Version must be a valid version (e.g., 1, 1.2, or 1.2.3)');
+    expect(validateField(field, '1')).toBeUndefined();
+    expect(validateField(field, '1.2')).toBeUndefined();
     expect(validateField(field, '1.2.3')).toBeUndefined();
   });
 

--- a/tests/components/AttestationForm.test.tsx
+++ b/tests/components/AttestationForm.test.tsx
@@ -385,7 +385,7 @@ describe('validateField function', () => {
 
   it('validates pattern with semver subtype', () => {
     const field = { name: 'version', label: 'Version', type: 'string', pattern: '^\\d+\\.\\d+\\.\\d+$', subtype: 'semver' };
-    expect(validateField(field, 'invalid')).toBe('Version must be a valid semantic version (e.g., 1.2.3)');
+    expect(validateField(field, 'invalid')).toBe('Version must be a valid version (e.g., 1, 1.2, or 1.2.3)');
     expect(validateField(field, '1.2.3')).toBeUndefined();
   });
 


### PR DESCRIPTION
## Summary
- Updates the `AttestationForm.test.tsx` semver subtype validation assertion to match the relaxed version message introduced in commit 4d23a0a.
- One-liner: `"Version must be a valid semantic version (e.g., 1.2.3)"` → `"Version must be a valid version (e.g., 1, 1.2, or 1.2.3)"`

## Test plan
- [ ] Run `npm test` and confirm the semver subtype test in `AttestationForm.test.tsx` passes
- [ ] Verify no other tests are affected