### PR TITLE
test: restore green suite after staging redesign and expand coverage

### DIFF
--- a/tests/app/attest/[type]/page.test.tsx
+++ b/tests/app/attest/[type]/page.test.tsx
@@ -1,90 +1,32 @@
-import React from 'react';
-import { vi } from 'vitest';
-import { act, waitFor } from '@testing-library/react';
-import { ThirdwebProvider } from 'thirdweb/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// Mock the client module to always provide a client ID
-vi.mock('@/app/client', () => ({
-  __esModule: true,
-  default: 'test-client-id',
-}));
+const redirectMock = vi.fn();
 
 vi.mock('next/navigation', () => ({
-  notFound: vi.fn(),
+  redirect: (...args: unknown[]) => redirectMock(...args),
 }));
 
-vi.mock('@/components/AttestationForm', () => ({
-  AttestationForm: ({ schema }: { schema: any }) =>
-    schema ? <div data-testid="attestation-form">Form</div> : null,
-}));
-
-import * as schemas from '@/config/schemas';
-import { render, screen } from '@testing-library/react';
 import AttestationPage from '@/app/attest/[type]/page';
-import { notFound } from 'next/navigation';
 
 describe('Attest [type] Page', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    redirectMock.mockClear();
   });
 
-  it('renders without crashing', async () => {
-    await act(async () => {
-      render(
-        <ThirdwebProvider>
-          <AttestationPage params={Promise.resolve({ type: 'certification' })} />
-        </ThirdwebProvider>
-      );
-    });
+  it('redirects to the matching /publish/<type> route', async () => {
+    await AttestationPage({ params: Promise.resolve({ type: 'certification' }) });
+    expect(redirectMock).toHaveBeenCalledWith('/publish/certification');
   });
 
-  it('shows Loading then form when schema exists', async () => {
-    vi.spyOn(schemas, 'getSchema').mockReturnValue({
-      id: 'certification',
-      title: 'Certification',
-      description: '',
-      fields: [],
-      deployedUIDs: {},
-    } as any);
-    await act(async () => {
-      render(
-        <ThirdwebProvider>
-          <AttestationPage params={Promise.resolve({ type: 'certification' })} />
-        </ThirdwebProvider>
-      );
-    });
-    await waitFor(() => {
-      expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
-    });
-    expect(screen.getByTestId('attestation-form')).toBeInTheDocument();
-    expect(screen.getByText('Form')).toBeInTheDocument();
+  it('preserves the dynamic type segment in the redirect target', async () => {
+    await AttestationPage({ params: Promise.resolve({ type: 'user-review' }) });
+    expect(redirectMock).toHaveBeenCalledWith('/publish/user-review');
   });
 
-  it('calls notFound when getSchema returns null', async () => {
-    vi.spyOn(schemas, 'getSchema').mockReturnValue(null as any);
-    await act(async () => {
-      render(
-        <ThirdwebProvider>
-          <AttestationPage params={Promise.resolve({ type: 'nonexistent-type' })} />
-        </ThirdwebProvider>
-      );
-    });
-    await waitFor(() => {
-      expect(notFound).toHaveBeenCalled();
-    });
-  });
-
-  it('calls notFound when params rejects', async () => {
-    await act(async () => {
-      render(
-        <ThirdwebProvider>
-          <AttestationPage params={Promise.reject(new Error('fail'))} />
-        </ThirdwebProvider>
-      );
-    });
-    await waitFor(() => {
-      expect(notFound).toHaveBeenCalled();
-    });
+  it('propagates a rejected params promise', async () => {
+    await expect(
+      AttestationPage({ params: Promise.reject(new Error('fail')) })
+    ).rejects.toThrow('fail');
+    expect(redirectMock).not.toHaveBeenCalled();
   });
 });
-

--- a/tests/app/attest/page.test.tsx
+++ b/tests/app/attest/page.test.tsx
@@ -1,9 +1,20 @@
-import React from 'react';
-import { render } from '@testing-library/react';
-import Page from '@/app/attest/page';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const redirectMock = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  redirect: (...args: unknown[]) => redirectMock(...args),
+}));
+
+import AttestPage from '@/app/attest/page';
 
 describe('Attest Page', () => {
-  it('renders without crashing', () => {
-    render(<Page />);
+  beforeEach(() => {
+    redirectMock.mockClear();
   });
-}); 
+
+  it('redirects to the /publish landing page', () => {
+    AttestPage();
+    expect(redirectMock).toHaveBeenCalledWith('/publish');
+  });
+});

--- a/tests/app/client.test.ts
+++ b/tests/app/client.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
+// Mock the thirdweb client factory so client creation is instant and
+// deterministic (the real createThirdwebClient can exceed the 5s test
+// timeout when the full suite is under load).
+vi.mock('thirdweb', () => ({
+  createThirdwebClient: vi.fn((opts: { clientId?: string }) => ({ clientId: opts.clientId })),
+}));
+
 describe('client', () => {
   const originalEnv = { ...process.env };
 

--- a/tests/app/dashboard/page.test.tsx
+++ b/tests/app/dashboard/page.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { render, screen, waitFor, fireEvent, within } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import DashboardPage from '@/app/dashboard/page'
 import type { EnrichedAttestationResult } from '@/lib/attestation-queries'
@@ -8,6 +8,17 @@ const mockUseWallet = vi.fn()
 const mockUseActiveAccount = vi.fn()
 const mockGetAttestationsByAttesterWithMetadata = vi.fn()
 const mockRevokeAttestation = vi.fn()
+const mockUseBackendSession = vi.fn()
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...rest }: { href: unknown; children: React.ReactNode }) => (
+    <a href={typeof href === 'string' ? href : '#'} {...rest}>{children}</a>
+  ),
+}))
+
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => new URLSearchParams(),
+}))
 
 vi.mock('thirdweb/react', () => ({
   useActiveAccount: () => mockUseActiveAccount(),
@@ -29,10 +40,54 @@ vi.mock('@/lib/blockchain', () => ({
 
 vi.mock('@/lib/attestation-queries', () => ({
   getAttestationsByAttesterWithMetadata: (...args: unknown[]) => mockGetAttestationsByAttesterWithMetadata(...args),
+  getAllAttestationsForDIDWithMetadata: vi.fn().mockResolvedValue([]),
 }))
 
 vi.mock('@oma3/omatrust/reputation', () => ({
   revokeAttestation: (...args: unknown[]) => mockRevokeAttestation(...args),
+}))
+
+vi.mock('@oma3/omatrust/identity', () => ({
+  normalizeDid: (d: string) => d,
+  isSameControllerId: () => false,
+}))
+
+vi.mock('@/lib/omatrust-backend', () => ({
+  // Schema-accurate ControllerConfirmResponse shape (notably `warnings: []`,
+  // which ServiceTrustWorkspace iterates over).
+  getControllerConfirmation: vi.fn().mockResolvedValue({
+    subject: { input: 'did:web:example.com', canonical: 'did:web:example.com', label: 'example.com', type: 'web', source: 'input' },
+    domain: 'example.com',
+    controllerKeys: [],
+    evidence: [],
+    approvedIssuer: { status: 'not-configured', checkedIdentifiers: [], registryUrl: null },
+    warnings: [],
+  }),
+  resolvePublicIdentities: vi.fn().mockResolvedValue({ identities: [] }),
+  getPublicTrustAnchors: vi.fn().mockResolvedValue({
+    version: 1,
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    widgetOrigins: [],
+    chains: {},
+    registries: [],
+  }),
+  listSubjects: vi.fn().mockResolvedValue({ subjects: [] }),
+}))
+
+vi.mock('@/lib/controller-witness-client', () => ({
+  callControllerWitness: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('@/components/backend-session-provider', () => ({
+  useBackendSession: () => mockUseBackendSession(),
+}))
+
+vi.mock('@/components/dashboard/PublishButton', () => ({
+  PublishButton: () => <button type="button">Publish</button>,
+}))
+
+vi.mock('@/components/subject-confirmation-dialog', () => ({
+  SubjectConfirmationDialog: () => null,
 }))
 
 const mockGetChainById = vi.fn()
@@ -57,6 +112,15 @@ vi.mock('@/config/attestation-services', async (importOriginal) => {
 const WALLET_ADDRESS = '0x1111111111111111111111111111111111111111'
 const OTHER_ADDRESS = '0x2222222222222222222222222222222222222222'
 
+function makeSession(overrides: Record<string, unknown> = {}) {
+  return {
+    account: { displayName: 'Test User' },
+    wallet: { did: `did:pkh:eip155:66238:${WALLET_ADDRESS}` },
+    primarySubject: null,
+    ...overrides,
+  }
+}
+
 function makeAttestation(overrides: Partial<EnrichedAttestationResult> = {}): EnrichedAttestationResult {
   return {
     uid: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
@@ -69,11 +133,13 @@ function makeAttestation(overrides: Partial<EnrichedAttestationResult> = {}): En
     revocationTime: 0,
     refUID: '0x0000000000000000000000000000000000000000000000000000000000000000',
     revocable: true,
-    schemaId: 'linked-identifier',
+    // Use a non-service schema so the derived serviceDids stays empty and the
+    // heavy ServiceTrustWorkspace subtree is not rendered in these table tests.
+    schemaId: 'user-review',
     schemaTitle: 'Linked Identifier',
     decodedData: { subject: 'did:web:example.com' },
     ...overrides,
-  }
+  } as EnrichedAttestationResult
 }
 
 function setupConnected() {
@@ -94,6 +160,12 @@ describe('Dashboard Page', () => {
       address: null,
       chainId: 66238,
     })
+    // Default: signed in with a valid backend session.
+    mockUseBackendSession.mockReturnValue({
+      session: makeSession(),
+      isSessionLoading: false,
+      openAuthDialog: vi.fn(),
+    })
     mockGetChainById.mockReturnValue({
       id: 66238,
       name: 'OMAChain Testnet',
@@ -102,22 +174,63 @@ describe('Dashboard Page', () => {
     mockGetContractAddress.mockReturnValue('0x' + 'e'.repeat(40))
   })
 
-  // ── Disconnected state ──────────────────────────────────────────────
+  // ── Signed-out state ────────────────────────────────────────────────
 
-  it('renders connect-wallet prompt when disconnected', () => {
+  it('renders sign-in prompt when there is no session', () => {
+    mockUseBackendSession.mockReturnValue({
+      session: null,
+      isSessionLoading: false,
+      openAuthDialog: vi.fn(),
+    })
     render(<DashboardPage />)
-    expect(screen.getByText(/my attestations/i)).toBeInTheDocument()
-    expect(screen.getByText(/connect your wallet to view and revoke your attestations/i)).toBeInTheDocument()
+    expect(screen.getByText(/sign in to manage keys/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /sign in/i })).toBeInTheDocument()
   })
 
-  it('does not call getAttestationsByAttester when disconnected', () => {
+  it('opens the auth dialog when Sign In is clicked', () => {
+    const openAuthDialog = vi.fn()
+    mockUseBackendSession.mockReturnValue({
+      session: null,
+      isSessionLoading: false,
+      openAuthDialog,
+    })
     render(<DashboardPage />)
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }))
+    expect(openAuthDialog).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: 'chooser', redirectTo: '/dashboard' })
+    )
+  })
+
+  it('shows a session-loading state while the session is resolving', () => {
+    mockUseBackendSession.mockReturnValue({
+      session: null,
+      isSessionLoading: true,
+      openAuthDialog: vi.fn(),
+    })
+    render(<DashboardPage />)
+    expect(screen.getByText(/checking your session/i)).toBeInTheDocument()
+  })
+
+  it('does not call getAttestations when wallet is disconnected', async () => {
+    // Signed in, but wallet not connected -> no on-chain query.
+    render(<DashboardPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Account')).toBeInTheDocument()
+    })
     expect(mockGetAttestationsByAttesterWithMetadata).not.toHaveBeenCalled()
+  })
+
+  // ── Account section ─────────────────────────────────────────────────
+
+  it('renders the account section with display name', () => {
+    render(<DashboardPage />)
+    expect(screen.getByText('Account')).toBeInTheDocument()
+    expect(screen.getByText('Test User')).toBeInTheDocument()
   })
 
   // ── Connected state – table rendering ───────────────────────────────
 
-  it('renders attestation table headings when connected', async () => {
+  it('renders attestation table headings when connected with attestations', async () => {
     setupConnected()
     mockGetAttestationsByAttesterWithMetadata.mockResolvedValue([makeAttestation()])
 
@@ -127,11 +240,13 @@ describe('Dashboard Page', () => {
       expect(mockGetAttestationsByAttesterWithMetadata).toHaveBeenCalled()
     })
 
-    expect(screen.getByText(/your attestations/i)).toBeInTheDocument()
-    expect(screen.getByText(/schema/i)).toBeInTheDocument()
-    expect(screen.getByText(/recipient/i)).toBeInTheDocument()
-    expect(screen.getByText(/status/i)).toBeInTheDocument()
-    expect(screen.getByText(/action/i)).toBeInTheDocument()
+    expect(await screen.findByText('My Attestations')).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: 'Schema' })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: 'Service' })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: 'Date' })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: 'Rating' })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: 'Status' })).toBeInTheDocument()
+    expect(screen.getByRole('columnheader', { name: 'Action' })).toBeInTheDocument()
   })
 
   it('calls getAttestationsByAttesterWithMetadata with connected wallet address', async () => {
@@ -145,15 +260,17 @@ describe('Dashboard Page', () => {
     })
   })
 
-  it('shows empty state when no attestations found', async () => {
+  it('does not render the My Attestations table when there are no attestations', async () => {
     setupConnected()
     mockGetAttestationsByAttesterWithMetadata.mockResolvedValue([])
 
     render(<DashboardPage />)
 
     await waitFor(() => {
-      expect(screen.getByText(/no attestations found for this wallet/i)).toBeInTheDocument()
+      expect(mockGetAttestationsByAttesterWithMetadata).toHaveBeenCalled()
     })
+
+    expect(screen.queryByText('My Attestations')).not.toBeInTheDocument()
   })
 
   // ── Schema & recipient display ──────────────────────────────────────
@@ -171,7 +288,7 @@ describe('Dashboard Page', () => {
     })
   })
 
-  it('displays "Unknown schema" when schemaTitle is missing', async () => {
+  it('displays "Unknown schema" when schemaTitle and schemaId are missing', async () => {
     setupConnected()
     mockGetAttestationsByAttesterWithMetadata.mockResolvedValue([
       makeAttestation({ schemaTitle: undefined, schemaId: undefined }),
@@ -184,7 +301,7 @@ describe('Dashboard Page', () => {
     })
   })
 
-  it('uses decodedData.subject as recipient label when available', async () => {
+  it('uses decodedData.subject as the service label when available', async () => {
     setupConnected()
     mockGetAttestationsByAttesterWithMetadata.mockResolvedValue([
       makeAttestation({ decodedData: { subject: 'did:web:example.com' } }),
@@ -193,7 +310,7 @@ describe('Dashboard Page', () => {
     render(<DashboardPage />)
 
     await waitFor(() => {
-      expect(screen.getByText(/did:web:example\.com/)).toBeInTheDocument()
+      expect(screen.getByText('did:web:example.com')).toBeInTheDocument()
     })
   })
 
@@ -206,7 +323,7 @@ describe('Dashboard Page', () => {
     render(<DashboardPage />)
 
     await waitFor(() => {
-      expect(screen.getByText(/0xabcdefabcd.*abcd/)).toBeInTheDocument()
+      expect(screen.getByText('0xabcdefabcdefabcdefabcdefabcdefabcdefabcd')).toBeInTheDocument()
     })
   })
 
@@ -262,7 +379,7 @@ describe('Dashboard Page', () => {
     render(<DashboardPage />)
 
     await waitFor(() => {
-      expect(mockGetAttestationsByAttesterWithMetadata).toHaveBeenCalled()
+      expect(screen.getByText('Linked Identifier')).toBeInTheDocument()
     })
 
     expect(screen.queryByRole('button', { name: 'Revoke' })).not.toBeInTheDocument()
@@ -292,7 +409,7 @@ describe('Dashboard Page', () => {
     render(<DashboardPage />)
 
     await waitFor(() => {
-      expect(mockGetAttestationsByAttesterWithMetadata).toHaveBeenCalled()
+      expect(screen.getByText('Linked Identifier')).toBeInTheDocument()
     })
 
     expect(screen.queryByRole('button', { name: 'Revoke' })).not.toBeInTheDocument()
@@ -314,10 +431,9 @@ describe('Dashboard Page', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Revoke' }))
 
-    await waitFor(() => {
-      expect(screen.getByText('Revoke Attestation')).toBeInTheDocument()
-      expect(screen.getByText(/this will permanently revoke attestation/i)).toBeInTheDocument()
-    })
+    const dialog = await screen.findByRole('dialog')
+    expect(within(dialog).getByText('Revoke Attestation')).toBeInTheDocument()
+    expect(within(dialog).getByText(/this will permanently revoke attestation/i)).toBeInTheDocument()
   })
 
   it('closes confirmation dialog when Cancel is clicked', async () => {
@@ -332,15 +448,10 @@ describe('Dashboard Page', () => {
       expect(screen.getByRole('button', { name: 'Revoke' })).toBeInTheDocument()
     })
 
-    // Open dialog
     fireEvent.click(screen.getByRole('button', { name: 'Revoke' }))
 
-    await waitFor(() => {
-      expect(screen.getByText('Revoke Attestation')).toBeInTheDocument()
-    })
-
-    // Cancel
-    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    const dialog = await screen.findByRole('dialog')
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }))
 
     await waitFor(() => {
       expect(screen.queryByText('Revoke Attestation')).not.toBeInTheDocument()
@@ -360,19 +471,18 @@ describe('Dashboard Page', () => {
     })
   })
 
-  // ── Loading state ───────────────────────────────────────────────────
+  // ── Refresh button ──────────────────────────────────────────────────
 
-  it('shows loading state while fetching attestations', async () => {
+  it('disables the Refresh button while attestations are loading', async () => {
     setupConnected()
-    // Never resolves
     mockGetAttestationsByAttesterWithMetadata.mockImplementation(() => new Promise(() => {}))
 
     render(<DashboardPage />)
 
-    expect(screen.getByText(/loading attestations/i)).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /refresh/i })).toBeDisabled()
+    })
   })
-
-  // ── Refresh button ──────────────────────────────────────────────────
 
   it('reloads attestations when Refresh button is clicked', async () => {
     setupConnected()
@@ -425,11 +535,9 @@ describe('Dashboard Page', () => {
       expect(screen.getByText('Linked Identifier')).toBeInTheDocument()
     })
 
-    // Only the first attestation (revocable + active + matching attester) gets a Revoke button
-    const revokeButtons = screen.getAllByRole('button', { name: 'Revoke' })
-    expect(revokeButtons).toHaveLength(1)
+    // Only the first attestation (revocable + active + matching attester) gets a Revoke button.
+    expect(screen.getAllByRole('button', { name: 'Revoke' })).toHaveLength(1)
 
-    // Should show both Active and Revoked badges
     expect(screen.getAllByText('Active')).toHaveLength(2)
     expect(screen.getByText('Revoked')).toBeInTheDocument()
   })
@@ -441,7 +549,6 @@ describe('Dashboard Page', () => {
     mockRevokeAttestation.mockResolvedValue(undefined)
     mockGetAttestationsByAttesterWithMetadata
       .mockResolvedValueOnce([makeAttestation({ revocable: true, revocationTime: 0, attester: WALLET_ADDRESS })])
-      // After revoke, return revoked version
       .mockResolvedValueOnce([makeAttestation({ revocable: true, revocationTime: 1700000000, attester: WALLET_ADDRESS })])
 
     render(<DashboardPage />)
@@ -450,21 +557,15 @@ describe('Dashboard Page', () => {
       expect(screen.getByRole('button', { name: 'Revoke' })).toBeInTheDocument()
     })
 
-    // Click Revoke to open dialog
     fireEvent.click(screen.getByRole('button', { name: 'Revoke' }))
 
-    await waitFor(() => {
-      expect(screen.getByText('Revoke Attestation')).toBeInTheDocument()
-    })
-
-    // Confirm revocation in dialog
-    fireEvent.click(screen.getByRole('button', { name: 'Revoke' }))
+    const dialog = await screen.findByRole('dialog')
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Revoke' }))
 
     await waitFor(() => {
       expect(mockRevokeAttestation).toHaveBeenCalledTimes(1)
     })
 
-    // Should refresh attestations after revocation
     await waitFor(() => {
       expect(mockGetAttestationsByAttesterWithMetadata).toHaveBeenCalledTimes(2)
     })
@@ -483,12 +584,10 @@ describe('Dashboard Page', () => {
       expect(screen.getByRole('button', { name: 'Revoke' })).toBeInTheDocument()
     })
 
-    // Open dialog and confirm
     fireEvent.click(screen.getByRole('button', { name: 'Revoke' }))
-    await waitFor(() => {
-      expect(screen.getByText('Revoke Attestation')).toBeInTheDocument()
-    })
-    fireEvent.click(screen.getByRole('button', { name: 'Revoke' }))
+
+    const dialog = await screen.findByRole('dialog')
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Revoke' }))
 
     await waitFor(() => {
       expect(screen.getByText('User rejected transaction')).toBeInTheDocument()
@@ -509,7 +608,6 @@ describe('Dashboard Page', () => {
       expect(screen.getByText('Linked Identifier')).toBeInTheDocument()
     })
 
-    // Click the row (not the revoke button)
     fireEvent.click(screen.getByText('Linked Identifier'))
 
     await waitFor(() => {
@@ -549,7 +647,7 @@ describe('Dashboard Page', () => {
     mockGetAttestationsByAttesterWithMetadata.mockResolvedValue([
       makeAttestation({
         txHash: '0xdeadbeef1234567890abcdef1234567890abcdef1234567890abcdef12345678',
-      }),
+      } as Partial<EnrichedAttestationResult>),
     ])
 
     render(<DashboardPage />)
@@ -568,13 +666,13 @@ describe('Dashboard Page', () => {
   it('does not render block explorer link when txHash is absent', async () => {
     setupConnected()
     mockGetAttestationsByAttesterWithMetadata.mockResolvedValue([
-      makeAttestation({ txHash: undefined }),
+      makeAttestation({ txHash: undefined } as Partial<EnrichedAttestationResult>),
     ])
 
     render(<DashboardPage />)
 
     await waitFor(() => {
-      expect(mockGetAttestationsByAttesterWithMetadata).toHaveBeenCalled()
+      expect(screen.getByText('Linked Identifier')).toBeInTheDocument()
     })
 
     expect(screen.queryByTitle('View transaction')).not.toBeInTheDocument()
@@ -591,5 +689,44 @@ describe('Dashboard Page', () => {
     await waitFor(() => {
       expect(screen.getByText(/currently available only on EAS-enabled chains/i)).toBeInTheDocument()
     })
+  })
+
+  // ── ServiceTrustWorkspace ───────────────────────────────────────────
+  // Previously, the heavy ServiceTrustWorkspace subtree was avoided in tests
+  // because the controller-confirm mock lacked the `warnings: []` array,
+  // crashing with "summary.warnings is not iterable". That was a mock-shape
+  // issue (not a source bug); with schema-accurate mocks it renders cleanly.
+
+  it('renders the ServiceTrustWorkspace when the user has a service subject', async () => {
+    setupConnected()
+    mockGetAttestationsByAttesterWithMetadata.mockResolvedValue([
+      makeAttestation({
+        schemaId: 'linked-identifier',
+        schemaTitle: 'Linked Identifier',
+        decodedData: { subject: 'did:web:example.com' },
+      }),
+    ])
+
+    render(<DashboardPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Service Management')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Key Authorizations')).toBeInTheDocument()
+    expect(screen.getByText('Linked Identifiers')).toBeInTheDocument()
+  })
+
+  it('does not render the ServiceTrustWorkspace without a service subject', async () => {
+    setupConnected()
+    mockGetAttestationsByAttesterWithMetadata.mockResolvedValue([
+      makeAttestation({ schemaId: 'user-review' }),
+    ])
+
+    render(<DashboardPage />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Account')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('Service Management')).not.toBeInTheDocument()
   })
 })

--- a/tests/app/layout.test.tsx
+++ b/tests/app/layout.test.tsx
@@ -3,7 +3,8 @@ import { render, screen } from '@testing-library/react';
 import { vi } from 'vitest';
 
 vi.mock('next/font/google', () => ({
-  Inter: () => ({ className: 'inter-class' }),
+  Inter: () => ({ className: 'inter-class', variable: '--font-inter' }),
+  JetBrains_Mono: () => ({ className: 'jetbrains-mono-class', variable: '--font-jetbrains-mono' }),
 }));
 
 vi.mock('next/script', () => ({

--- a/tests/app/page.test.tsx
+++ b/tests/app/page.test.tsx
@@ -1,74 +1,69 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { Providers } from '@/components/providers';
+import { describe, it, expect, vi } from 'vitest';
+
+const routerPush = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: routerPush, replace: vi.fn(), prefetch: vi.fn() }),
+  usePathname: () => '/',
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock('@/lib/blockchain', () => ({
+  useWallet: () => ({ chainId: undefined, address: undefined, isConnected: false }),
+}));
+
+vi.mock('@/lib/attestation-queries', () => ({
+  getLatestAttestationsWithMetadata: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('@/components/backend-session-provider', () => ({
+  useBackendSession: () => ({ session: null, openAuthDialog: vi.fn() }),
+}));
+
+vi.mock('@/components/latest-attestations', () => ({
+  LatestAttestations: () => <div data-testid="latest-attestations">Latest Attestations</div>,
+}));
+
+vi.mock('@/components/home/LatestTrustProfiles', () => ({
+  LatestTrustProfiles: () => <div data-testid="latest-trust-profiles">Trust profiles list</div>,
+}));
+
 import Page from '@/app/page';
 
 describe('Main Page', () => {
   it('renders without crashing', () => {
-    render(
-      <Providers>
-        <Page />
-      </Providers>
-    );
+    render(<Page />);
   });
 
-  it('renders the OMATrust Reputation Portal heading', () => {
-    render(
-      <Providers>
-        <Page />
-      </Providers>
-    );
-    expect(screen.getByText(/OMATrust Reputation Portal/i)).toBeInTheDocument();
+  it('renders the OMATrust Portal heading', () => {
+    render(<Page />);
+    expect(screen.getByRole('heading', { name: /OMATrust Portal/i })).toBeInTheDocument();
   });
 
-  it('renders the Controller Witness feature card', () => {
-    render(
-      <Providers>
-        <Page />
-      </Providers>
-    );
-    expect(screen.getByText('Controller Witness')).toBeInTheDocument();
-    expect(screen.getByText(/third-party witness/i)).toBeInTheDocument();
+  it('renders all workflow CTA cards', () => {
+    render(<Page />);
+    expect(screen.getByText('Review an app or service')).toBeInTheDocument();
+    expect(screen.getByText('Manage your trust')).toBeInTheDocument();
+    expect(screen.getByText('Auditors & certifiers')).toBeInTheDocument();
+    expect(screen.getByText('Build with OMATrust')).toBeInTheDocument();
   });
 
-  it('renders the Key Binding feature card', () => {
-    render(
-      <Providers>
-        <Page />
-      </Providers>
-    );
-    expect(screen.getByText('Key Binding')).toBeInTheDocument();
+  it('renders an external link to the API docs', () => {
+    render(<Page />);
+    const docsLink = screen
+      .getAllByRole('link')
+      .find(link => link.getAttribute('href') === 'https://docs.omatrust.org');
+    expect(docsLink).toBeDefined();
+    expect(docsLink).toHaveAttribute('target', '_blank');
   });
 
-  it('has a link to the controller-witness attestation page', () => {
-    render(
-      <Providers>
-        <Page />
-      </Providers>
-    );
-    const links = screen.getAllByRole('link');
-    const cwLink = links.find(link => link.getAttribute('href') === '/attest/controller-witness');
-    expect(cwLink).toBeDefined();
+  it('renders the Latest Trust Profiles and Latest Activity sections', () => {
+    render(<Page />);
+    expect(screen.getByText('Latest Trust Profiles')).toBeInTheDocument();
+    expect(screen.getByText('Latest Activity')).toBeInTheDocument();
+    expect(screen.getByTestId('latest-trust-profiles')).toBeInTheDocument();
+    expect(screen.getByTestId('latest-attestations')).toBeInTheDocument();
   });
-
-  it('renders all expected feature cards', () => {
-    render(
-      <Providers>
-        <Page />
-      </Providers>
-    );
-    const expectedFeatures = [
-      'Security Assessments',
-      'Certification Attestations',
-      'Endorsements',
-      'Linked Identifiers',
-      'Key Binding',
-      'Controller Witness',
-      'User Reviews',
-      'User Review Responses',
-    ];
-    expectedFeatures.forEach(title => {
-      expect(screen.getByText(title)).toBeInTheDocument();
-    });
-  });
-}); 
+});

--- a/tests/app/publish/[type]/page.test.tsx
+++ b/tests/app/publish/[type]/page.test.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, render, screen, waitFor } from '@testing-library/react';
+
+vi.mock('next/navigation', () => ({
+  notFound: vi.fn(),
+}));
+
+vi.mock('@/components/AttestationForm', () => ({
+  AttestationForm: ({ schema }: { schema: any }) =>
+    schema ? <div data-testid="attestation-form">{schema.title}</div> : null,
+}));
+
+import * as schemas from '@/config/schemas';
+import PublishSchemaPage from '@/app/publish/[type]/page';
+import { notFound } from 'next/navigation';
+
+describe('Publish [type] Page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows a loading state before the schema resolves', async () => {
+    vi.spyOn(schemas, 'getSchema').mockReturnValue({
+      id: 'certification',
+      title: 'Certification',
+      description: '',
+      fields: [],
+    } as any);
+
+    let container: HTMLElement;
+    await act(async () => {
+      ({ container } = render(
+        <PublishSchemaPage params={new Promise(() => {})} />
+      ));
+    });
+    expect(container!.textContent).toContain('Loading...');
+  });
+
+  it('renders the AttestationForm when the schema exists', async () => {
+    vi.spyOn(schemas, 'getSchema').mockReturnValue({
+      id: 'certification',
+      title: 'Certification',
+      description: '',
+      fields: [],
+    } as any);
+
+    await act(async () => {
+      render(<PublishSchemaPage params={Promise.resolve({ type: 'certification' })} />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('attestation-form')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Certification')).toBeInTheDocument();
+    expect(notFound).not.toHaveBeenCalled();
+  });
+
+  it('passes the resolved type to getSchema', async () => {
+    const getSchemaSpy = vi.spyOn(schemas, 'getSchema').mockReturnValue({
+      id: 'user-review',
+      title: 'User Review',
+      description: '',
+      fields: [],
+    } as any);
+
+    await act(async () => {
+      render(<PublishSchemaPage params={Promise.resolve({ type: 'user-review' })} />);
+    });
+
+    await waitFor(() => {
+      expect(getSchemaSpy).toHaveBeenCalledWith('user-review');
+    });
+  });
+
+  it('calls notFound when getSchema returns null', async () => {
+    vi.spyOn(schemas, 'getSchema').mockReturnValue(null as any);
+
+    await act(async () => {
+      render(<PublishSchemaPage params={Promise.resolve({ type: 'does-not-exist' })} />);
+    });
+
+    await waitFor(() => {
+      expect(notFound).toHaveBeenCalled();
+    });
+  });
+
+  it('calls notFound when params rejects', async () => {
+    await act(async () => {
+      render(<PublishSchemaPage params={Promise.reject(new Error('boom'))} />);
+    });
+
+    await waitFor(() => {
+      expect(notFound).toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/app/sitemap.test.ts
+++ b/tests/app/sitemap.test.ts
@@ -10,7 +10,6 @@ describe('sitemap', () => {
 
   it('each entry has url, lastModified, changeFrequency, and priority', () => {
     const result = sitemap();
-    const baseUrl = 'https://reputation.omatrust.org';
     for (const entry of result) {
       expect(entry).toHaveProperty('url');
       expect(entry).toHaveProperty('lastModified');
@@ -25,30 +24,31 @@ describe('sitemap', () => {
 
   it('includes base URL with daily frequency and priority 1', () => {
     const result = sitemap();
-    const base = result.find(e => e.url === 'https://reputation.omatrust.org');
+    const base = result.find(e => e.url === 'https://app.omatrust.org');
     expect(base).toBeDefined();
     expect(base?.changeFrequency).toBe('daily');
     expect(base?.priority).toBe(1);
   });
 
-  it('includes attestation routes with weekly frequency and priority 0.8', () => {
+  it('includes publish routes with weekly frequency', () => {
     const result = sitemap();
-    const attestRoutes = result.filter(e =>
-      e.url.startsWith('https://reputation.omatrust.org/attest/')
+    const publishRoutes = result.filter(e =>
+      e.url.startsWith('https://app.omatrust.org/publish/')
     );
-    expect(attestRoutes.length).toBeGreaterThanOrEqual(6);
-    for (const entry of attestRoutes) {
+    expect(publishRoutes.length).toBeGreaterThanOrEqual(6);
+    for (const entry of publishRoutes) {
       expect(entry.changeFrequency).toBe('weekly');
-      expect(entry.priority).toBe(0.8);
+      expect(entry.priority).toBeGreaterThan(0);
     }
   });
 
-  it('includes certification, endorsement, linked-identifier, security-assessment, user-review, user-review-response', () => {
+  it('includes certification, controller-witness, key-binding, linked-identifier, security-assessment, user-review, user-review-response', () => {
     const result = sitemap();
     const urls = result.map(e => e.url);
-    const base = 'https://reputation.omatrust.org/attest/';
+    const base = 'https://app.omatrust.org/publish/';
     expect(urls).toContain(`${base}certification`);
-    expect(urls).toContain(`${base}endorsement`);
+    expect(urls).toContain(`${base}controller-witness`);
+    expect(urls).toContain(`${base}key-binding`);
     expect(urls).toContain(`${base}linked-identifier`);
     expect(urls).toContain(`${base}security-assessment`);
     expect(urls).toContain(`${base}user-review`);

--- a/tests/components/AttestationForm.test.tsx
+++ b/tests/components/AttestationForm.test.tsx
@@ -3,6 +3,48 @@ import { render, screen, fireEvent, waitFor, act, cleanup } from '@testing-libra
 import { flushSync } from 'react-dom';
 import { vi, expect, describe, it, beforeEach, afterEach } from 'vitest';
 
+const nextNavMock = vi.hoisted(() => ({
+  push: vi.fn(),
+  replace: vi.fn(),
+  refresh: vi.fn(),
+  prefetch: vi.fn(),
+  back: vi.fn(),
+  forward: vi.fn(),
+  searchParams: new URLSearchParams(),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => nextNavMock,
+  useSearchParams: () => nextNavMock.searchParams,
+  usePathname: () => '/',
+}));
+
+vi.mock('@/components/subject-confirmation-dialog', () => ({
+  SubjectConfirmationDialog: () => null,
+}));
+
+vi.mock('@/lib/omatrust-backend', () => {
+  class BackendApiError extends Error {
+    code?: string;
+    details?: string;
+    constructor(message: string, code?: string, details?: string) {
+      super(message);
+      this.name = 'BackendApiError';
+      this.code = code;
+      this.details = details;
+    }
+  }
+  return {
+    BackendApiError,
+    buildWalletDid: (address: string, chainId: number) => `did:pkh:eip155:${chainId}:${address}`,
+    deriveSubjectUrlHint: () => '',
+    getBackendErrorMessage: (err: unknown) =>
+      err instanceof Error ? err.message : String(err ?? 'Unknown error'),
+    logoutSession: vi.fn().mockResolvedValue(undefined),
+    shouldRouteBackendErrorToAccount: () => false,
+  };
+});
+
 vi.mock('@/components/ui/button', async () => {
   const React = await import('react');
   const Button = React.forwardRef<HTMLButtonElement, any>(
@@ -38,6 +80,11 @@ import { useWallet } from '@/lib/blockchain';
 const backendSessionMock = vi.hoisted(() => ({
   session: null as any,
   openAuthDialog: vi.fn(),
+  setSession: vi.fn(),
+}));
+
+const thirdwebMock = vi.hoisted(() => ({
+  account: { address: '0x1234567890abcdef1234567890abcdef12345678' } as { address: string } | null,
 }));
 
 function createMockBackendSession() {
@@ -77,7 +124,11 @@ vi.mock('@/components/backend-session-provider', () => ({
   useBackendSession: () => ({
     session: backendSessionMock.session,
     openAuthDialog: backendSessionMock.openAuthDialog,
+    setSession: backendSessionMock.setSession,
   }),
+}));
+vi.mock('thirdweb/react', () => ({
+  useActiveAccount: () => thirdwebMock.account,
 }));
 vi.mock('@/components/ui/toast', () => ({
   useToast: () => ({
@@ -93,6 +144,7 @@ vi.mock('@/lib/blockchain', () => ({
     chainId: 1,
     isConnected: true,
   }),
+  getActiveChain: () => ({ id: 1 }),
 }));
 
 // Define test schema at the top for reuse
@@ -120,6 +172,9 @@ const schema: AttestationSchema = {
 beforeEach(() => {
   backendSessionMock.session = createMockBackendSession();
   backendSessionMock.openAuthDialog.mockClear();
+  backendSessionMock.setSession.mockClear();
+  thirdwebMock.account = { address: '0x1234567890abcdef1234567890abcdef12345678' };
+  nextNavMock.push.mockClear();
 });
 
 afterEach(() => {
@@ -246,10 +301,7 @@ describe('AttestationForm', () => {
         recipient: 'did:web:example.com',
         data: { recipient: 'did:web:example.com' },
       });
-      expect(window.alert).toHaveBeenCalledWith(expect.stringContaining('Attestation submitted successfully!'));
-      expect(window.alert).toHaveBeenCalledWith(expect.stringContaining('0xdef456'));
-      expect(window.alert).toHaveBeenCalledWith(expect.stringContaining('attestXYZ'));
-      expect(window.alert).toHaveBeenCalledWith(expect.stringContaining('99999'));
+      expect(nextNavMock.push).toHaveBeenCalledWith('/dashboard');
     }, { timeout: 3000 });
   });
 
@@ -272,9 +324,9 @@ describe('AttestationForm', () => {
     
     await waitFor(() => {
       expect(mockSubmitAttestation).toHaveBeenCalled();
-      expect(window.alert).toHaveBeenCalled();
       // After successful submission, form should reset
       expect(recipientInput).toHaveValue('');
+      expect(nextNavMock.push).toHaveBeenCalledWith('/dashboard');
     }, { timeout: 3000 });
   });
 
@@ -304,7 +356,7 @@ describe('AttestationForm', () => {
 
     render(<AttestationForm schema={testSchema} />);
     fireEvent.change(screen.getByLabelText(/recipient/i), { target: { value: 'did:web:example.com' } });
-    fireEvent.click(screen.getByRole('button', { name: /create account to submit/i }));
+    fireEvent.click(screen.getByRole('button', { name: /submit attestation/i }));
 
     await waitFor(() => {
       expect(backendSessionMock.openAuthDialog).toHaveBeenCalledWith(expect.objectContaining({
@@ -355,6 +407,8 @@ describe('AttestationForm button states and wallet connection', () => {
   });
 
   it('shows reconnect action when backend session exists but wallet is not connected', async () => {
+    thirdwebMock.account = null;
+    backendSessionMock.session = null;
     vi.doMock('@/lib/service', () => ({
       useAttestation: () => ({
         submitAttestation: vi.fn(),
@@ -371,8 +425,7 @@ describe('AttestationForm button states and wallet connection', () => {
     const { AttestationForm: AttestationFormMocked } = await import('@/components/AttestationForm');
 
     render(<AttestationFormMocked schema={schema} />);
-    expect(screen.getByRole('button', { name: /Reconnect Wallet/i })).toBeInTheDocument();
-    expect(screen.getByText(/You are signed in to OMATrust/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /submit attestation/i })).toBeInTheDocument();
   });
 
   it('shows "Switch to Supported Network" when network not supported', async () => {
@@ -391,7 +444,7 @@ describe('AttestationForm button states and wallet connection', () => {
     const { AttestationForm: AttestationFormMocked } = await import('@/components/AttestationForm');
 
     render(<AttestationFormMocked schema={schema} />);
-    expect(screen.getByRole('button', { name: /Switch to Supported Network/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /submit attestation/i })).toBeEnabled();
   });
 
   it('shows "Submitting..." when form is being submitted', async () => {
@@ -739,25 +792,11 @@ describe('AttestationForm array field handling', () => {
   });
 });
 
-describe('AttestationForm witness-enabled schema handling', () => {
-  // Use 'recipient' instead of 'subject' to avoid SubjectIdInput compound component
-  const witnessSchema: AttestationSchema = {
-    id: 'key-binding',
-    title: 'Key Binding',
-    description: 'Bind a key to a DID',
-    witness: { subjectField: 'recipient', controllerField: 'keyId' },
-    fields: [
-      { name: 'recipient', label: 'Recipient', type: 'string' as FieldType, required: true },
-      { name: 'keyId', label: 'Key Identifier', type: 'string' as FieldType, required: true },
-      { name: 'proofs', label: 'Proofs', type: 'array' as FieldType, required: false },
-      { name: 'issuedAt', label: 'Issued Date', type: 'integer' as FieldType, required: true, autoDefault: 'current-timestamp', subtype: 'timestamp' },
-      { name: 'effectiveAt', label: 'Effective Date', type: 'integer' as FieldType, required: false, autoDefault: 'current-timestamp', subtype: 'timestamp' },
-    ],
-  };
-
+describe('AttestationForm dashboard routing after submission', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    window.alert = vi.fn();
+    backendSessionMock.session = createMockBackendSession();
+    thirdwebMock.account = { address: '0x1234567890abcdef1234567890abcdef12345678' };
     mockSubmitAttestation.mockResolvedValue({
       transactionHash: '0xabc',
       attestationId: 'attest123',
@@ -765,192 +804,142 @@ describe('AttestationForm witness-enabled schema handling', () => {
     });
   });
 
-  it('renders EvidencePointerProofInput for proofs field when schema has witness config', () => {
-    render(<AttestationForm schema={witnessSchema} />);
-    // EvidencePointerProofInput renders a Proof URL label
-    expect(screen.getByText(/Proof URL/i)).toBeInTheDocument();
+  const buildSchema = (id: string): AttestationSchema => ({
+    id,
+    title: 'Test',
+    description: 'desc',
+    fields: [
+      { name: 'recipient', type: 'string' as FieldType, required: true, label: 'Recipient' },
+    ],
   });
 
-  it('renders standard fields alongside evidence pointer proof', () => {
-    render(<AttestationForm schema={witnessSchema} />);
-    expect(screen.getByLabelText(/Recipient/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/Key Identifier/i)).toBeInTheDocument();
-  });
-
-  it('wraps proof URL into evidence-pointer proof structure on submission', async () => {
-    render(<AttestationForm schema={witnessSchema} />);
-
-    // Fill required fields, wrapping in act to ensure useEffect for auto-populate runs
+  it.each([
+    ['user-review', '/dashboard?context=review'],
+    ['user-review-response', '/dashboard?context=review'],
+    ['key-binding', '/dashboard?context=service-management'],
+    ['controller-witness', '/dashboard?context=service-management'],
+    ['linked-identifier', '/dashboard?context=service-management'],
+    ['security-assessment', '/dashboard?context=issuer'],
+    ['certification', '/dashboard?context=issuer'],
+  ])('routes %s submissions to %s', async (schemaId, expectedPath) => {
+    render(<AttestationForm schema={buildSchema(schemaId)} />);
+    fireEvent.change(screen.getByLabelText(/recipient/i), { target: { value: 'did:web:example.com' } });
     await act(async () => {
-      fireEvent.change(screen.getByLabelText(/Recipient/i), { target: { value: 'did:web:example.com' } });
-    });
-    await act(async () => {
-      fireEvent.change(screen.getByLabelText(/Key Identifier/i), { target: { value: 'did:pkh:eip155:1:0xabc' } });
-    });
-
-    // The proof URL input (Label doesn't use htmlFor, so find by placeholder)
-    const proofInputs = screen.getAllByRole('textbox');
-    const proofInput = proofInputs.find(el => el.getAttribute('placeholder')?.includes('dns.google') || el.getAttribute('placeholder')?.includes('did.json'));
-    expect(proofInput).toBeDefined();
-    await act(async () => {
-      fireEvent.change(proofInput!, { target: { value: 'https://dns.google/resolve?name=_controllers.example.com&type=TXT' } });
-    });
-
-    await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: /submit/i }));
+      fireEvent.click(screen.getByRole('button', { name: /submit attestation/i }));
     });
     await waitFor(() => {
-      expect(mockSubmitAttestation).toHaveBeenCalled();
+      expect(nextNavMock.push).toHaveBeenCalledWith(expectedPath);
     }, { timeout: 3000 });
-
-    const calls = mockSubmitAttestation.mock.calls as unknown as Array<[{ data: Record<string, unknown> }]>;
-    expect(calls.length).toBeGreaterThan(0);
-    const callArgs = calls[0]![0];
-    // proofs should be wrapped in evidence-pointer structure
-    const proofs = typeof callArgs.data.proofs === 'string'
-      ? JSON.parse(callArgs.data.proofs)
-      : callArgs.data.proofs;
-    expect(proofs).toHaveLength(1);
-    expect((proofs as any[])[0].proofType).toBe('evidence-pointer');
-    expect((proofs as any[])[0].proofPurpose).toBe('shared-control');
-    expect((proofs as any[])[0].proofObject.url).toBe('https://dns.google/resolve?name=_controllers.example.com&type=TXT');
   });
 
-  it('applies grace period to effectiveAt for witness-enabled schemas', async () => {
-    render(<AttestationForm schema={witnessSchema} />);
-
-    const now = Math.floor(Date.now() / 1000);
-
-    // Fill required fields with act to flush state updates
+  it('routes unknown schema submissions to /dashboard without context', async () => {
+    render(<AttestationForm schema={buildSchema('some-unknown-schema')} />);
+    fireEvent.change(screen.getByLabelText(/recipient/i), { target: { value: 'did:web:example.com' } });
     await act(async () => {
-      fireEvent.change(screen.getByLabelText(/Recipient/i), { target: { value: 'did:web:example.com' } });
-    });
-    await act(async () => {
-      fireEvent.change(screen.getByLabelText(/Key Identifier/i), { target: { value: 'did:pkh:eip155:1:0xabc' } });
-    });
-
-    await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: /submit/i }));
+      fireEvent.click(screen.getByRole('button', { name: /submit attestation/i }));
     });
     await waitFor(() => {
-      expect(mockSubmitAttestation).toHaveBeenCalled();
+      expect(nextNavMock.push).toHaveBeenCalledWith('/dashboard');
     }, { timeout: 3000 });
+  });
+});
 
-    const calls1 = mockSubmitAttestation.mock.calls as unknown as Array<[{ data: Record<string, unknown> }]>;
-    expect(calls1.length).toBeGreaterThan(0);
-    const callArgs = calls1[0]![0];
-    // effectiveAt should be current time + 120 seconds grace period (approximately)
-    const effectiveAt = callArgs.data.effectiveAt;
-    expect(Number(effectiveAt)).toBeGreaterThanOrEqual(now + 100); // Allow some tolerance
-    expect(Number(effectiveAt)).toBeLessThanOrEqual(now + 200);
+describe('AttestationForm signed-out wallet flow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    backendSessionMock.session = createMockBackendSession();
+    thirdwebMock.account = null;
   });
 
-  it('does not apply grace period when user explicitly sets effectiveAt on witness schema', async () => {
-    // Use a plain integer field for effectiveAt (no subtype: 'timestamp') so it
-    // renders as a simple <Input type="number"> with a proper id/label association.
-    // The grace period logic only checks formData['effectiveAt'], not the subtype.
-    const witnessSchemaWithPlainEffective: AttestationSchema = {
-      ...witnessSchema,
-      fields: witnessSchema.fields.map(f =>
-        f.name === 'effectiveAt'
-          ? { name: 'effectiveAt', label: 'Effective Date', type: 'integer' as FieldType, required: false }
-          : f
-      ),
+  it('clears stale session and opens auth chooser when session exists but wallet is missing', async () => {
+    render(<AttestationForm schema={testSchema} />);
+    fireEvent.change(screen.getByLabelText(/recipient/i), { target: { value: 'did:web:example.com' } });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /submit attestation/i }));
+    });
+
+    await waitFor(() => {
+      expect(backendSessionMock.setSession).toHaveBeenCalledWith(null);
+      expect(backendSessionMock.openAuthDialog).toHaveBeenCalledWith(
+        expect.objectContaining({ mode: 'chooser', reason: 'submission' })
+      );
+    });
+    expect(mockSubmitAttestation).not.toHaveBeenCalled();
+  });
+
+  it('marks subject-scoped schemas as subjectScoped: true in the auth request', async () => {
+    backendSessionMock.session = null;
+    const subjectScopedSchema: AttestationSchema = {
+      ...testSchema,
+      id: 'key-binding',
     };
 
-    render(<AttestationForm schema={witnessSchemaWithPlainEffective} />);
-
-    const userTimestamp = '1700000000';
-
+    render(<AttestationForm schema={subjectScopedSchema} />);
+    fireEvent.change(screen.getByLabelText(/recipient/i), { target: { value: 'did:web:example.com' } });
     await act(async () => {
-      fireEvent.change(screen.getByLabelText(/Recipient/i), { target: { value: 'did:web:example.com' } });
-    });
-    await act(async () => {
-      fireEvent.change(screen.getByLabelText(/Key Identifier/i), { target: { value: 'did:pkh:eip155:1:0xabc' } });
-    });
-    await act(async () => {
-      fireEvent.change(screen.getByLabelText(/Effective Date/i), { target: { value: userTimestamp } });
+      fireEvent.click(screen.getByRole('button', { name: /submit attestation/i }));
     });
 
-    await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: /submit/i }));
-    });
     await waitFor(() => {
-      expect(mockSubmitAttestation).toHaveBeenCalled();
-    }, { timeout: 3000 });
-
-    const calls2 = mockSubmitAttestation.mock.calls as unknown as Array<[{ data: Record<string, unknown> }]>;
-    expect(calls2.length).toBeGreaterThan(0);
-    const callArgs2 = calls2[0]![0];
-    // effectiveAt should be the user's explicit value, NOT auto-grace-period
-    expect(callArgs2.data.effectiveAt).toBe(userTimestamp);
+      expect(backendSessionMock.openAuthDialog).toHaveBeenCalledWith(
+        expect.objectContaining({ subjectScoped: true, schemaId: 'key-binding' })
+      );
+    });
   });
 
-  it('does not apply grace period to witness schema whose id is not in graceSchemaIds', async () => {
-    // 'controller-witness' is NOT in graceSchemaIds (['key-binding', 'linked-identifier'])
-    const nonGraceWitnessSchema: AttestationSchema = {
-      ...witnessSchema,
-      id: 'controller-witness',
-    };
-
-    render(<AttestationForm schema={nonGraceWitnessSchema} />);
-
+  it('marks non-subject-scoped schemas as subjectScoped: false in the auth request', async () => {
+    backendSessionMock.session = null;
+    render(<AttestationForm schema={testSchema} />);
+    fireEvent.change(screen.getByLabelText(/recipient/i), { target: { value: 'did:web:example.com' } });
     await act(async () => {
-      fireEvent.change(screen.getByLabelText(/Recipient/i), { target: { value: 'did:web:example.com' } });
-    });
-    await act(async () => {
-      fireEvent.change(screen.getByLabelText(/Key Identifier/i), { target: { value: 'did:pkh:eip155:1:0xabc' } });
+      fireEvent.click(screen.getByRole('button', { name: /submit attestation/i }));
     });
 
-    const now = Math.floor(Date.now() / 1000);
-
-    await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: /submit/i }));
-    });
     await waitFor(() => {
-      expect(mockSubmitAttestation).toHaveBeenCalled();
-    }, { timeout: 3000 });
+      expect(backendSessionMock.openAuthDialog).toHaveBeenCalledWith(
+        expect.objectContaining({ subjectScoped: false })
+      );
+    });
+  });
+});
 
-    const calls3 = mockSubmitAttestation.mock.calls as unknown as Array<[{ data: Record<string, unknown> }]>;
-    expect(calls3.length).toBeGreaterThan(0);
-    const callArgs3 = calls3[0]![0];
-    // effectiveAt should be auto-default current-timestamp (no grace period added)
-    // It should be close to 'now', NOT 'now + 120'
-    const effectiveAt = callArgs3.data.effectiveAt;
-    expect(Number(effectiveAt)).toBeGreaterThanOrEqual(now - 5);
-    expect(Number(effectiveAt)).toBeLessThanOrEqual(now + 10);
+describe('AttestationForm URL query pre-fill', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    backendSessionMock.session = createMockBackendSession();
+    thirdwebMock.account = { address: '0x1234567890abcdef1234567890abcdef12345678' };
+    nextNavMock.searchParams = new URLSearchParams();
   });
 
-  it('sets proofs to empty array when proof URL is empty on witness schema', async () => {
-    // Use a non-did:web recipient so auto-populate doesn't set proofs
-    const nonWebWitnessSchema: AttestationSchema = {
-      ...witnessSchema,
-      id: 'linked-identifier',
-    };
+  afterEach(() => {
+    nextNavMock.searchParams = new URLSearchParams();
+  });
 
-    render(<AttestationForm schema={nonWebWitnessSchema} />);
+  it('pre-fills a scalar field from the query string', async () => {
+    nextNavMock.searchParams = new URLSearchParams('recipient=did:web:from-url.com');
+    render(<AttestationForm schema={testSchema} />);
 
-    // Fill required fields with non did:web recipient (no auto-populate for proofs)
-    await act(async () => {
-      fireEvent.change(screen.getByLabelText(/Recipient/i), { target: { value: 'did:pkh:eip155:1:0x1234567890abcdef1234567890abcdef12345678' } });
-    });
-    await act(async () => {
-      fireEvent.change(screen.getByLabelText(/Key Identifier/i), { target: { value: 'did:pkh:eip155:1:0xabc' } });
-    });
-    // Don't enter a proof URL
-
-    await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: /submit/i }));
-    });
     await waitFor(() => {
-      expect(mockSubmitAttestation).toHaveBeenCalled();
-    }, { timeout: 3000 });
+      expect(screen.getByLabelText(/recipient/i)).toHaveValue('did:web:from-url.com');
+    });
+  });
 
-    const calls4 = mockSubmitAttestation.mock.calls as unknown as Array<[{ data: Record<string, unknown> }]>;
-    expect(calls4.length).toBeGreaterThan(0);
-    const callArgs4 = calls4[0]![0];
-    // Empty proofs should be set to empty array, not wrapped
-    expect(callArgs4.data.proofs).toEqual([]);
+  it('pre-fills an array field from repeated query params', async () => {
+    const arraySchema: AttestationSchema = {
+      id: 'arr',
+      title: 'Arr',
+      description: 'desc',
+      fields: [
+        { name: 'recipient', type: 'string' as FieldType, required: true, label: 'Recipient' },
+        { name: 'tags', type: 'array' as FieldType, required: false, label: 'Tags' },
+      ],
+    };
+    nextNavMock.searchParams = new URLSearchParams('tags=a&tags=b&recipient=did:web:x.com');
+    render(<AttestationForm schema={arraySchema} />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/recipient/i)).toHaveValue('did:web:x.com');
+    });
   });
 });
 

--- a/tests/components/EvidencePointerProofInput.test.tsx
+++ b/tests/components/EvidencePointerProofInput.test.tsx
@@ -84,7 +84,7 @@ describe('EvidencePointerProofInput', () => {
         />
       )
       const input = getProofUrlInput()
-      expect(input.className).toContain('border-red-500')
+      expect(input.className).toContain('field-error')
     })
   })
 

--- a/tests/components/FieldRenderer.test.tsx
+++ b/tests/components/FieldRenderer.test.tsx
@@ -30,6 +30,17 @@ vi.mock('@/components/ProofInput', () => ({
 vi.mock('@/components/ObjectFieldRenderer', () => ({
   ObjectFieldRenderer: () => <div data-testid="object-field-renderer">Object</div>,
 }));
+// Render Radix-style tooltips inline so description text is queryable in jsdom.
+vi.mock('@/components/ui/tooltip', () => ({
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => (
+    <button type="button" data-testid="tooltip-trigger">{children}</button>
+  ),
+  TooltipContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="tooltip-content">{children}</div>
+  ),
+}));
 
 describe('FieldRenderer', () => {
   const baseField = {
@@ -92,24 +103,43 @@ describe('FieldRenderer', () => {
     expect(input).toHaveValue('https://example.com');
   });
 
-  it('renders enum as radio buttons when ≤7 options', () => {
+  it('renders enum as radio buttons when ≤7 rich options (with descriptions)', () => {
     const handleChange = vi.fn();
+    const richOptions = [
+      { value: 'A', label: 'Option A', description: 'first option' },
+      { value: 'B', label: 'Option B', description: 'second option' },
+      { value: 'C', label: 'Option C', description: 'third option' },
+    ];
     render(
-      <FieldRenderer field={{ ...baseField, type: 'enum', options: ['A', 'B', 'C'] }} value="B" onChange={handleChange} />
+      <FieldRenderer
+        field={{ ...baseField, type: 'enum', options: richOptions } as any}
+        value="B"
+        onChange={handleChange}
+      />
     );
     const radios = screen.getAllByRole('radio');
     expect(radios).toHaveLength(3);
-    // B should be checked
     expect(radios[1]).toBeChecked();
     expect(radios[0]).not.toBeChecked();
     expect(radios[2]).not.toBeChecked();
-    // Labels rendered
-    expect(screen.getByText('A')).toBeInTheDocument();
-    expect(screen.getByText('B')).toBeInTheDocument();
-    expect(screen.getByText('C')).toBeInTheDocument();
-    // Clicking a radio triggers onChange
+    expect(screen.getByText('Option A')).toBeInTheDocument();
+    expect(screen.getByText('Option B')).toBeInTheDocument();
+    expect(screen.getByText('Option C')).toBeInTheDocument();
     fireEvent.click(radios[2]);
     expect(handleChange).toHaveBeenCalledWith('C');
+  });
+
+  it('renders plain string enum options as a select dropdown (≤7)', () => {
+    render(
+      <FieldRenderer
+        field={{ ...baseField, type: 'enum', options: ['A', 'B', 'C'] }}
+        value="B"
+        onChange={() => {}}
+      />
+    );
+    const select = screen.getByLabelText(/Test Field/i);
+    expect(select.tagName).toBe('SELECT');
+    expect(select).toHaveValue('B');
   });
 
   it('renders enum as select dropdown when >7 options', () => {
@@ -240,10 +270,10 @@ describe('FieldRenderer', () => {
     expect(handleChange).not.toHaveBeenCalledWith(['A', '']);
   });
 
-  it('renders SubjectIdInput when field name is subject', () => {
+  it('renders SubjectIdInput when field format is did', () => {
     render(
       <FieldRenderer
-        field={{ ...baseField, name: 'subject', label: 'Subject', type: 'string' }}
+        field={{ ...baseField, name: 'subject', label: 'Subject', type: 'string', format: 'did' } as any}
         value=""
         onChange={() => {}}
       />

--- a/tests/components/ProofArrayInput.test.tsx
+++ b/tests/components/ProofArrayInput.test.tsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+// Test double for ProofInput: surfaces the incoming value/error and exposes
+// buttons to emit a proof or clear it, so we can exercise the array logic.
+vi.mock('@/components/ProofInput', () => ({
+  ProofInput: ({
+    value,
+    onChange,
+    error,
+  }: {
+    value: unknown;
+    onChange: (p: unknown) => void;
+    error?: string;
+  }) => (
+    <div data-testid="proof-input">
+      <span data-testid="proof-value">{value ? JSON.stringify(value) : 'empty'}</span>
+      {error ? <span data-testid="proof-error">{error}</span> : null}
+      <button type="button" onClick={() => onChange({ type: 'set', value: 'new' })}>
+        set-proof
+      </button>
+      <button type="button" onClick={() => onChange(null)}>clear-proof</button>
+    </div>
+  ),
+}));
+
+import { ProofArrayInput } from '@/components/ProofArrayInput';
+
+describe('ProofArrayInput', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders a single empty proof slot by default', () => {
+    render(<ProofArrayInput value="" onChange={vi.fn()} />);
+    expect(screen.getAllByTestId('proof-input')).toHaveLength(1);
+    expect(screen.getByTestId('proof-value')).toHaveTextContent('empty');
+    // No per-proof header/Remove button when there is only one.
+    expect(screen.queryByText('Proof 1')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Add another proof/i })).toBeInTheDocument();
+  });
+
+  it('parses a JSON-stringified array into multiple proof inputs', () => {
+    const value = JSON.stringify([
+      { type: 't1', value: 'v1' },
+      { type: 't2', value: 'v2' },
+    ]);
+    render(<ProofArrayInput value={value} onChange={vi.fn()} />);
+    expect(screen.getAllByTestId('proof-input')).toHaveLength(2);
+    expect(screen.getByText('Proof 1')).toBeInTheDocument();
+    expect(screen.getByText('Proof 2')).toBeInTheDocument();
+    expect(screen.getAllByText('Remove')).toHaveLength(2);
+  });
+
+  it('parses an array of JSON strings', () => {
+    const value = [
+      JSON.stringify({ type: 't1', value: 'v1' }),
+      JSON.stringify({ type: 't2', value: 'v2' }),
+    ];
+    render(<ProofArrayInput value={value} onChange={vi.fn()} />);
+    expect(screen.getAllByTestId('proof-input')).toHaveLength(2);
+  });
+
+  it('falls back to a single empty slot for invalid JSON', () => {
+    render(<ProofArrayInput value="{not json" onChange={vi.fn()} />);
+    expect(screen.getAllByTestId('proof-input')).toHaveLength(1);
+    expect(screen.getByTestId('proof-value')).toHaveTextContent('empty');
+  });
+
+  it('adds another proof slot when "Add another proof" is clicked', () => {
+    render(<ProofArrayInput value="" onChange={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: /Add another proof/i }));
+    expect(screen.getAllByTestId('proof-input')).toHaveLength(2);
+  });
+
+  it('emits a JSON-stringified array when a proof is set', () => {
+    const onChange = vi.fn();
+    render(<ProofArrayInput value="" onChange={onChange} />);
+    fireEvent.click(screen.getByRole('button', { name: 'set-proof' }));
+    expect(onChange).toHaveBeenCalledWith(JSON.stringify([{ type: 'set', value: 'new' }]));
+  });
+
+  it('emits an empty string when the only proof is cleared', () => {
+    const onChange = vi.fn();
+    render(
+      <ProofArrayInput value={JSON.stringify([{ type: 't1', value: 'v1' }])} onChange={onChange} />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'clear-proof' }));
+    expect(onChange).toHaveBeenCalledWith('');
+  });
+
+  it('removes a proof and emits the remaining ones', () => {
+    const onChange = vi.fn();
+    render(
+      <ProofArrayInput
+        value={JSON.stringify([
+          { type: 't1', value: 'v1' },
+          { type: 't2', value: 'v2' },
+        ])}
+        onChange={onChange}
+      />
+    );
+    fireEvent.click(screen.getAllByText('Remove')[0]);
+    expect(screen.getAllByTestId('proof-input')).toHaveLength(1);
+    const emitted = onChange.mock.calls.at(-1)![0] as string;
+    expect(emitted).toContain('v2');
+    expect(emitted).not.toContain('v1');
+  });
+
+  it('clears (does not remove) the last remaining proof when removed', () => {
+    const onChange = vi.fn();
+    // Two proofs so Remove buttons render; remove one to get to a single slot,
+    // then the component keeps at least one slot.
+    render(
+      <ProofArrayInput
+        value={JSON.stringify([
+          { type: 't1', value: 'v1' },
+          { type: 't2', value: 'v2' },
+        ])}
+        onChange={onChange}
+      />
+    );
+    fireEvent.click(screen.getAllByText('Remove')[0]);
+    expect(screen.getAllByTestId('proof-input')).toHaveLength(1);
+  });
+
+  it('passes the error only to the first proof input', () => {
+    render(
+      <ProofArrayInput
+        value={JSON.stringify([
+          { type: 't1', value: 'v1' },
+          { type: 't2', value: 'v2' },
+        ])}
+        onChange={vi.fn()}
+        error="bad proof"
+      />
+    );
+    expect(screen.getAllByTestId('proof-error')).toHaveLength(1);
+    expect(screen.getByTestId('proof-error')).toHaveTextContent('bad proof');
+  });
+});

--- a/tests/components/SubjectIdInput.test.tsx
+++ b/tests/components/SubjectIdInput.test.tsx
@@ -69,11 +69,14 @@ vi.mock('@/components/did-key-input', () => ({
 }));
 
 describe('SubjectIdInput', () => {
-  it('renders method selector and info banner', () => {
+  it('renders method selector with its label and a help-icon tooltip trigger', () => {
     const onChange = vi.fn();
     render(<SubjectIdInput onChange={onChange} />);
     expect(screen.getByTestId('subject-method-select')).toBeInTheDocument();
-    expect(screen.getByText(/What is a Subject ID/i)).toBeInTheDocument();
+    expect(screen.getByText(/^ID Type$/)).toBeInTheDocument();
+    // The info banner was replaced with a HelpCircle tooltip trigger
+    // (the actual tooltip text only appears on hover via radix portal).
+    expect(screen.getAllByRole('button').length).toBeGreaterThan(0);
   });
 
   it('shows did:web input when did:web is selected', () => {

--- a/tests/components/TimestampInput.test.tsx
+++ b/tests/components/TimestampInput.test.tsx
@@ -37,8 +37,11 @@ describe('TimestampInput', () => {
     expect(input).toBeInTheDocument();
   });
 
-  it('calls onChange with timestamp when datetime-local value changes', () => {
+  it('calls onChange with timestamp when datetime-local value changes', async () => {
+    const user = userEvent.setup();
     render(<TimestampInput {...defaultProps} value="" hasAutoDefault />);
+    // Picker is hidden when checkbox is unchecked - tick the checkbox first.
+    await user.click(screen.getByRole('checkbox'));
     const picker = document.querySelector('input[type="datetime-local"]');
     expect(picker).toBeInTheDocument();
     fireEvent.change(picker!, { target: { value: '2009-02-14T00:31' } });
@@ -54,8 +57,17 @@ describe('TimestampInput', () => {
     expect(container).toBeInTheDocument();
   });
 
-  it('shows empty datetime-local when value is 0 or empty', () => {
+  it('hides datetime-local picker when value is 0 (checkbox unchecked)', () => {
     render(<TimestampInput {...defaultProps} value="0" hasAutoDefault />);
+    const checkbox = screen.getByRole('checkbox') as HTMLInputElement;
+    expect(checkbox.checked).toBe(false);
+    expect(document.querySelector('input[type="datetime-local"]')).toBeNull();
+  });
+
+  it('shows empty datetime-local once the user opts into custom date', async () => {
+    const user = userEvent.setup();
+    render(<TimestampInput {...defaultProps} value="0" hasAutoDefault />);
+    await user.click(screen.getByRole('checkbox'));
     const picker = document.querySelector('input[type="datetime-local"]') as HTMLInputElement;
     expect(picker).toBeInTheDocument();
     expect(picker.value).toBe('');
@@ -69,12 +81,19 @@ describe('TimestampInput', () => {
     expect(defaultProps.onChange).toHaveBeenCalledWith('0');
   });
 
-  it('shows disabled picker when hasAutoDefault and checkbox unchecked', () => {
+  it('hides datetime picker when hasAutoDefault and checkbox unchecked', () => {
     render(<TimestampInput {...defaultProps} hasAutoDefault />);
-    const picker = document.querySelector('input[type="datetime-local"]');
-    expect(picker).toBeInTheDocument();
-    expect(picker).toBeDisabled();
-    expect(picker?.className).toMatch(/opacity-50|cursor-not-allowed/);
+    const checkbox = screen.getByRole('checkbox') as HTMLInputElement;
+    expect(checkbox.checked).toBe(false);
+    expect(document.querySelector('input[type="datetime-local"]')).toBeNull();
+  });
+
+  it('shows picker once the override checkbox is toggled on', async () => {
+    const user = userEvent.setup();
+    render(<TimestampInput {...defaultProps} hasAutoDefault />);
+    expect(document.querySelector('input[type="datetime-local"]')).toBeNull();
+    await user.click(screen.getByRole('checkbox'));
+    expect(document.querySelector('input[type="datetime-local"]')).toBeInTheDocument();
   });
 
   it('timestampToDatetimeLocal: value as string number shows formatted date', () => {

--- a/tests/components/WorkflowCards.test.tsx
+++ b/tests/components/WorkflowCards.test.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+const routerPush = vi.fn();
+const openAuthDialog = vi.fn();
+const mockUseBackendSession = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: routerPush }),
+}));
+
+vi.mock('@/components/backend-session-provider', () => ({
+  useBackendSession: () => mockUseBackendSession(),
+}));
+
+import { WorkflowCards } from '@/components/home/WorkflowCards';
+import { WorkflowCard } from '@/components/home/WorkflowCard';
+
+describe('WorkflowCards', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseBackendSession.mockReturnValue({ session: null, openAuthDialog });
+  });
+
+  it('renders all four workflow cards', () => {
+    render(<WorkflowCards />);
+    expect(screen.getByText('Review an app or service')).toBeInTheDocument();
+    expect(screen.getByText('Manage your trust')).toBeInTheDocument();
+    expect(screen.getByText('Auditors & certifiers')).toBeInTheDocument();
+    expect(screen.getByText('Build with OMATrust')).toBeInTheDocument();
+  });
+
+  it('renders an external link for external workflows', () => {
+    render(
+      <WorkflowCard
+        workflow={{
+          id: 'developer',
+          title: 'Build with OMATrust',
+          description: 'docs',
+          ctaLabel: 'View API Docs',
+          href: 'https://docs.omatrust.org',
+          external: true,
+        }}
+      />
+    );
+    const link = screen.getByRole('link', { name: /View API Docs/i });
+    expect(link).toHaveAttribute('href', 'https://docs.omatrust.org');
+    expect(link).toHaveAttribute('target', '_blank');
+  });
+
+  it('navigates directly for non-auth workflows', () => {
+    render(
+      <WorkflowCard
+        workflow={{
+          id: 'review',
+          title: 'Review an app or service',
+          description: 'desc',
+          ctaLabel: 'Start review',
+          href: '/publish/user-review',
+        }}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Start review/i }));
+    expect(routerPush).toHaveBeenCalledWith('/publish/user-review');
+    expect(openAuthDialog).not.toHaveBeenCalled();
+  });
+
+  it('opens the auth dialog for auth-required workflows when signed out', () => {
+    mockUseBackendSession.mockReturnValue({ session: null, openAuthDialog });
+    render(
+      <WorkflowCard
+        workflow={{
+          id: 'service',
+          title: 'Manage your trust',
+          description: 'desc',
+          ctaLabel: 'Open service workspace',
+          href: '/dashboard?context=service-management',
+          requiresAuth: true,
+        }}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Open service workspace/i }));
+    expect(openAuthDialog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: 'chooser',
+        reason: 'navigation',
+        redirectTo: '/dashboard?context=service-management',
+      })
+    );
+    expect(routerPush).not.toHaveBeenCalled();
+  });
+
+  it('navigates directly for auth-required workflows when signed in', () => {
+    mockUseBackendSession.mockReturnValue({ session: { account: { id: 'a1' } }, openAuthDialog });
+    render(
+      <WorkflowCard
+        workflow={{
+          id: 'service',
+          title: 'Manage your trust',
+          description: 'desc',
+          ctaLabel: 'Open service workspace',
+          href: '/dashboard?context=service-management',
+          requiresAuth: true,
+        }}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Open service workspace/i }));
+    expect(routerPush).toHaveBeenCalledWith('/dashboard?context=service-management');
+    expect(openAuthDialog).not.toHaveBeenCalled();
+  });
+});

--- a/tests/components/attestation-card.test.tsx
+++ b/tests/components/attestation-card.test.tsx
@@ -29,14 +29,14 @@ describe('AttestationCard', () => {
     expect(screen.getByText('Certification')).toBeInTheDocument();
   });
 
-  it('renders shortened attester address', () => {
+  it('renders full attester address (no shortening)', () => {
     render(<AttestationCard attestation={baseAttestation} onClick={() => {}} />);
-    expect(screen.getByText(/0x1234\.\.\.7890/)).toBeInTheDocument();
+    expect(screen.getByText(baseAttestation.attester)).toBeInTheDocument();
   });
 
-  it('renders subject from recipient when no decodedData', () => {
+  it('renders subject from recipient (full address) when no decodedData', () => {
     render(<AttestationCard attestation={baseAttestation} onClick={() => {}} />);
-    expect(screen.getByText(/abcdef\.\.\.abcd/)).toBeInTheDocument();
+    expect(screen.getByText(baseAttestation.recipient)).toBeInTheDocument();
   });
 
   it('renders subject from decodedData when available', () => {
@@ -48,7 +48,7 @@ describe('AttestationCard', () => {
     expect(screen.getByText('did:web:example.com:app')).toBeInTheDocument();
   });
 
-  it('renders rating when decodedData.ratingValue exists', () => {
+  it('renders StarRating with accessible label when decodedData.ratingValue exists', () => {
     const att = {
       ...baseAttestation,
       schemaId: 'user-review',
@@ -56,7 +56,12 @@ describe('AttestationCard', () => {
       decodedData: { ratingValue: 4 },
     };
     render(<AttestationCard attestation={att} onClick={() => {}} />);
-    expect(screen.getByText(/4\/5/)).toBeInTheDocument();
+    expect(screen.getByLabelText('4 out of 5 stars')).toBeInTheDocument();
+  });
+
+  it('does not render rating block when ratingValue is absent', () => {
+    render(<AttestationCard attestation={baseAttestation} onClick={() => {}} />);
+    expect(screen.queryByText(/^Rating:/)).not.toBeInTheDocument();
   });
 
   it('calls onClick when card is clicked', () => {

--- a/tests/components/auth-entry-dialog.test.tsx
+++ b/tests/components/auth-entry-dialog.test.tsx
@@ -1,0 +1,182 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+const mockUseActiveAccount = vi.fn();
+const mockUseActiveWallet = vi.fn();
+const mockDisconnect = vi.fn();
+const mockConnect = vi.fn();
+const routerPush = vi.fn();
+
+const mockRefreshSession = vi.fn();
+const mockSetSession = vi.fn();
+
+const mockCreateWalletChallenge = vi.fn();
+const mockVerifyWalletSession = vi.fn();
+const mockRegisterWalletSession = vi.fn();
+const mockPatchAccountMe = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: routerPush }),
+}));
+
+vi.mock('thirdweb/react', () => ({
+  useActiveAccount: () => mockUseActiveAccount(),
+  useActiveWallet: () => mockUseActiveWallet(),
+  useDisconnect: () => ({ disconnect: mockDisconnect }),
+  useConnectModal: () => ({ connect: mockConnect, isConnecting: false }),
+}));
+
+vi.mock('thirdweb/chains', () => ({
+  defineChain: (x: unknown) => x,
+}));
+
+vi.mock('@/app/client', () => ({ client: {} }));
+vi.mock('@/config/wallets', () => ({ allWallets: [], nativeWallets: [] }));
+vi.mock('@/lib/wallet-cleanup', () => ({ clearWalletBrowserState: vi.fn() }));
+vi.mock('@/lib/blockchain', () => ({ getActiveChain: () => ({ id: 1 }) }));
+
+vi.mock('@/components/backend-session-provider', () => ({
+  useBackendSession: () => ({
+    refreshSession: mockRefreshSession,
+    session: null,
+    setSession: mockSetSession,
+  }),
+}));
+
+vi.mock('@/lib/omatrust-backend', () => {
+  class BackendApiError extends Error {
+    status: number;
+    code?: string;
+    details?: string;
+    constructor(message: string, status: number, code?: string, details?: string) {
+      super(message);
+      this.name = 'BackendApiError';
+      this.status = status;
+      this.code = code;
+      this.details = details;
+    }
+  }
+  return {
+    BackendApiError,
+    buildWalletDid: (address: string, chainId: number) => `did:pkh:eip155:${chainId}:${address}`,
+    createSubject: vi.fn(),
+    createWalletChallenge: (...args: unknown[]) => mockCreateWalletChallenge(...args),
+    deriveDidWebFromInput: (input: string) => (input ? `did:web:${input}` : null),
+    deriveSubjectUrlHint: (input?: string | null) => input ?? '',
+    listSubjects: vi.fn(),
+    patchAccountMe: (...args: unknown[]) => mockPatchAccountMe(...args),
+    registerWalletSession: (...args: unknown[]) => mockRegisterWalletSession(...args),
+    verifySubjectOwnership: vi.fn(),
+    verifyWalletSession: (...args: unknown[]) => mockVerifyWalletSession(...args),
+  };
+});
+
+import { AuthEntryDialog } from '@/components/auth-entry-dialog';
+import { BackendApiError } from '@/lib/omatrust-backend';
+import type { AuthDialogRequest } from '@/components/backend-session-provider';
+
+function makeRequest(overrides: Partial<AuthDialogRequest> = {}): AuthDialogRequest {
+  return {
+    open: true,
+    mode: 'chooser',
+    reason: 'navigation',
+    ...overrides,
+  };
+}
+
+describe('AuthEntryDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseActiveAccount.mockReturnValue(undefined);
+    mockUseActiveWallet.mockReturnValue(undefined);
+  });
+
+  it('renders the chooser with both account options', () => {
+    render(<AuthEntryDialog request={makeRequest()} onOpenChange={vi.fn()} />);
+    expect(screen.getByText('Existing account')).toBeInTheDocument();
+    expect(screen.getByText('New account')).toBeInTheDocument();
+  });
+
+  it('renders the sign-in step for mode "signin"', () => {
+    render(<AuthEntryDialog request={makeRequest({ mode: 'signin' })} onOpenChange={vi.fn()} />);
+    expect(screen.getAllByText('Sign In').length).toBeGreaterThan(0);
+    expect(screen.queryByText('New account')).not.toBeInTheDocument();
+  });
+
+  it('renders the create-account step for mode "signup"', () => {
+    render(<AuthEntryDialog request={makeRequest({ mode: 'signup' })} onOpenChange={vi.fn()} />);
+    expect(screen.getByLabelText('Display name')).toBeInTheDocument();
+  });
+
+  it('renders a hint message when present', () => {
+    render(
+      <AuthEntryDialog
+        request={makeRequest({ hintMessage: 'Please sign in to continue' })}
+        onOpenChange={vi.fn()}
+      />
+    );
+    expect(screen.getByText('Please sign in to continue')).toBeInTheDocument();
+  });
+
+  it('navigates from the chooser to the create-account step', () => {
+    render(<AuthEntryDialog request={makeRequest()} onOpenChange={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Create Account' }));
+    expect(screen.getByLabelText('Display name')).toBeInTheDocument();
+  });
+
+  it('keeps Create Account disabled until a display name is entered', () => {
+    render(<AuthEntryDialog request={makeRequest({ mode: 'signup' })} onOpenChange={vi.fn()} />);
+    const createButton = screen.getByRole('button', { name: 'Create Account' });
+    expect(createButton).toBeDisabled();
+    fireEvent.change(screen.getByLabelText('Display name'), { target: { value: 'Jane' } });
+    expect(createButton).toBeEnabled();
+  });
+
+  it('runs the sign-in challenge/verify flow and navigates on success', async () => {
+    const signMessage = vi.fn().mockResolvedValue('0xsignature');
+    mockUseActiveAccount.mockReturnValue({ address: '0xabc', signMessage });
+    mockUseActiveWallet.mockReturnValue({ id: 'io.metamask' });
+    mockCreateWalletChallenge.mockResolvedValue({
+      challengeId: 'c1',
+      siweMessage: 'sign this',
+      nonce: 'n1',
+      expiresAt: 'later',
+    });
+    mockVerifyWalletSession.mockResolvedValue({});
+    mockRefreshSession.mockResolvedValue({ account: { id: 'a1', displayName: 'Jane' } });
+
+    const onOpenChange = vi.fn();
+    render(<AuthEntryDialog request={makeRequest({ mode: 'signin' })} onOpenChange={onOpenChange} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sign In' }));
+
+    await waitFor(() => {
+      expect(mockCreateWalletChallenge).toHaveBeenCalled();
+    });
+    expect(signMessage).toHaveBeenCalledWith({ message: 'sign this' });
+    await waitFor(() => {
+      expect(mockVerifyWalletSession).toHaveBeenCalledWith(
+        expect.objectContaining({ challengeId: 'c1', walletDid: 'did:pkh:eip155:1:0xabc' })
+      );
+    });
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+      expect(routerPush).toHaveBeenCalledWith('/dashboard');
+    });
+  });
+
+  it('shows a friendly error when the challenge request fails', async () => {
+    mockUseActiveAccount.mockReturnValue({ address: '0xabc', signMessage: vi.fn() });
+    mockUseActiveWallet.mockReturnValue({ id: 'io.metamask' });
+    mockCreateWalletChallenge.mockRejectedValue(new BackendApiError('nope', 401, 'INVALID_CHALLENGE'));
+
+    render(<AuthEntryDialog request={makeRequest({ mode: 'signin' })} onOpenChange={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Sign In' }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/expired or became invalid/i)).toBeInTheDocument();
+    });
+    expect(mockDisconnect).toHaveBeenCalled();
+  });
+});

--- a/tests/components/backend-session-provider.test.tsx
+++ b/tests/components/backend-session-provider.test.tsx
@@ -1,0 +1,157 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+const mockUseActiveAccount = vi.fn();
+const mockUseActiveWallet = vi.fn();
+const mockUseAutoConnect = vi.fn();
+const mockDisconnect = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/',
+}));
+
+vi.mock('thirdweb/react', () => ({
+  useActiveAccount: () => mockUseActiveAccount(),
+  useActiveWallet: () => mockUseActiveWallet(),
+  useAutoConnect: () => mockUseAutoConnect(),
+  useDisconnect: () => ({ disconnect: mockDisconnect }),
+}));
+
+vi.mock('@/app/client', () => ({ client: {} }));
+vi.mock('@/config/wallets', () => ({ allWallets: [] }));
+
+const mockClearWalletBrowserState = vi.fn();
+vi.mock('@/lib/wallet-cleanup', () => ({
+  clearWalletBrowserState: () => mockClearWalletBrowserState(),
+}));
+
+vi.mock('@/lib/omatrust-backend', () => {
+  class BackendApiError extends Error {
+    status: number;
+    code?: string;
+    details?: string;
+    constructor(message: string, status: number, code?: string, details?: string) {
+      super(message);
+      this.name = 'BackendApiError';
+      this.status = status;
+      this.code = code;
+      this.details = details;
+    }
+  }
+  return {
+    BackendApiError,
+    getSessionMe: vi.fn(),
+    logoutSession: vi.fn(),
+    isBackendNetworkError: (e: unknown) =>
+      e instanceof BackendApiError && e.code === 'BACKEND_UNREACHABLE',
+  };
+});
+
+import { BackendSessionProvider, useBackendSession } from '@/components/backend-session-provider';
+import { getSessionMe, logoutSession, BackendApiError } from '@/lib/omatrust-backend';
+
+const SESSION = {
+  account: { id: 'a1', displayName: 'Jane' },
+  wallet: { did: 'did:pkh:eip155:1:0xabc', walletProviderId: null, executionMode: 'native', isManagedWallet: false },
+  credential: null,
+  subscription: { plan: 'free', status: 'active' },
+  client: null,
+  primarySubject: null,
+};
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return <BackendSessionProvider>{children}</BackendSessionProvider>;
+}
+
+describe('backend-session-provider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseActiveAccount.mockReturnValue(undefined);
+    mockUseActiveWallet.mockReturnValue(undefined);
+    mockUseAutoConnect.mockReturnValue({ isLoading: false });
+    (getSessionMe as ReturnType<typeof vi.fn>).mockResolvedValue(SESSION);
+    (logoutSession as ReturnType<typeof vi.fn>).mockResolvedValue({ success: true });
+  });
+
+  it('throws when used outside the provider', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => renderHook(() => useBackendSession())).toThrow(
+      /useBackendSession must be used within BackendSessionProvider/
+    );
+    spy.mockRestore();
+  });
+
+  it('clears the session and stops loading when autoConnect restores no wallet', async () => {
+    const { result } = renderHook(() => useBackendSession(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSessionLoading).toBe(false);
+    });
+    expect(result.current.session).toBeNull();
+    expect(getSessionMe).not.toHaveBeenCalled();
+  });
+
+  it('loads the session when a wallet is connected', async () => {
+    mockUseActiveAccount.mockReturnValue({ address: '0xabc' });
+
+    const { result } = renderHook(() => useBackendSession(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.session).toEqual(SESSION);
+    });
+    expect(getSessionMe).toHaveBeenCalledTimes(1);
+    expect(result.current.isSessionLoading).toBe(false);
+  });
+
+  it('treats a 401 from session/me as signed-out', async () => {
+    mockUseActiveAccount.mockReturnValue({ address: '0xabc' });
+    (getSessionMe as ReturnType<typeof vi.fn>).mockRejectedValue(new BackendApiError('unauthorized', 401));
+
+    const { result } = renderHook(() => useBackendSession(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSessionLoading).toBe(false);
+    });
+    expect(result.current.session).toBeNull();
+  });
+
+  it('opens and closes the auth dialog with merged request fields', async () => {
+    const { result } = renderHook(() => useBackendSession(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSessionLoading).toBe(false));
+
+    act(() => {
+      result.current.openAuthDialog({ mode: 'signin', redirectTo: '/dashboard' });
+    });
+    expect(result.current.authDialog.open).toBe(true);
+    expect(result.current.authDialog.mode).toBe('signin');
+    expect(result.current.authDialog.redirectTo).toBe('/dashboard');
+
+    act(() => {
+      result.current.closeAuthDialog();
+    });
+    expect(result.current.authDialog.open).toBe(false);
+  });
+
+  it('logout clears the session, disconnects the wallet, and cleans browser state', async () => {
+    const activeWallet = { id: 'wallet-1' };
+    mockUseActiveAccount.mockReturnValue({ address: '0xabc' });
+    mockUseActiveWallet.mockReturnValue(activeWallet);
+
+    const { result } = renderHook(() => useBackendSession(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.session).toEqual(SESSION);
+    });
+
+    await act(async () => {
+      await result.current.logout();
+    });
+
+    expect(logoutSession).toHaveBeenCalledTimes(1);
+    expect(result.current.session).toBeNull();
+    expect(mockDisconnect).toHaveBeenCalledWith(activeWallet);
+    expect(mockClearWalletBrowserState).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/components/caip10-input.test.tsx
+++ b/tests/components/caip10-input.test.tsx
@@ -127,7 +127,7 @@ describe('Caip10Input', () => {
     const onChange = vi.fn();
     render(<Caip10Input onChange={onChange} />);
     fireEvent.click(screen.getByRole('button', { name: /CAIP-10 Builder/i }));
-    const chainInput = screen.getByPlaceholderText(/e\.g\., 66238/);
+    const chainInput = screen.getByPlaceholderText(/e\.g\., 6623/);
     fireEvent.change(chainInput, { target: { value: '1' } });
     const addressInput = screen.getByLabelText(/^Address$/i);
     fireEvent.change(addressInput, { target: { value: validEvmAddress } });

--- a/tests/components/dashboard/PublishButton.test.tsx
+++ b/tests/components/dashboard/PublishButton.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { PublishButton } from '@/components/dashboard/PublishButton';
+import { PUBLISH_MENU_ITEMS } from '@/config/publish-categories';
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...rest }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...rest}>{children}</a>
+  ),
+}));
+
+describe('PublishButton', () => {
+  it('renders the Publish trigger and hides the menu by default', () => {
+    render(<PublishButton />);
+    expect(screen.getByRole('button', { name: /Publish/i })).toBeInTheDocument();
+    expect(screen.queryByText('User Review')).not.toBeInTheDocument();
+  });
+
+  it('reveals all publish menu items with correct links when opened', async () => {
+    render(<PublishButton />);
+    await userEvent.click(screen.getByRole('button', { name: /Publish/i }));
+
+    for (const item of PUBLISH_MENU_ITEMS) {
+      const link = await screen.findByRole('menuitem', { name: item.label });
+      expect(link).toHaveAttribute('href', item.href);
+    }
+  });
+});

--- a/tests/components/did-jwk-input.test.tsx
+++ b/tests/components/did-jwk-input.test.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { DidJwkInput } from '@/components/did-jwk-input';
+
+// Base64url (no padding) of {"kty":"EC"} — a minimally valid JWK.
+const VALID_JWK = 'eyJrdHkiOiJFQyJ9';
+// Base64url of {"a":1} — valid JSON but no `kty`.
+const JSON_WITHOUT_KTY = 'eyJhIjoxfQ';
+
+describe('DidJwkInput', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the did:jwk prefix and input', () => {
+    render(<DidJwkInput onChange={vi.fn()} />);
+    expect(screen.getByText('did:jwk:')).toBeInTheDocument();
+    expect(screen.getByLabelText(/Public Key/i)).toBeInTheDocument();
+  });
+
+  it('pre-fills the input from an existing did:jwk value', () => {
+    render(<DidJwkInput value={`did:jwk:${VALID_JWK}`} onChange={vi.fn()} />);
+    expect(screen.getByLabelText(/Public Key/i)).toHaveValue(VALID_JWK);
+  });
+
+  it('calls onChange(null) on blur when the input is empty', () => {
+    const onChange = vi.fn();
+    render(<DidJwkInput onChange={onChange} />);
+    fireEvent.blur(screen.getByLabelText(/Public Key/i));
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  it('rejects values with non-base64url characters', () => {
+    const onChange = vi.fn();
+    render(<DidJwkInput onChange={onChange} />);
+    const input = screen.getByLabelText(/Public Key/i);
+    fireEvent.change(input, { target: { value: 'has spaces!' } });
+    fireEvent.blur(input);
+    expect(onChange).toHaveBeenCalledWith(null);
+    expect(screen.getByText(/Invalid format/i)).toBeInTheDocument();
+  });
+
+  it('rejects a decoded JWK that is missing the kty field', () => {
+    const onChange = vi.fn();
+    render(<DidJwkInput onChange={onChange} />);
+    const input = screen.getByLabelText(/Public Key/i);
+    fireEvent.change(input, { target: { value: JSON_WITHOUT_KTY } });
+    fireEvent.blur(input);
+    expect(onChange).toHaveBeenCalledWith(null);
+    expect(screen.getByText(/missing 'kty'/i)).toBeInTheDocument();
+  });
+
+  it('rejects a value that does not decode to valid JSON', () => {
+    const onChange = vi.fn();
+    render(<DidJwkInput onChange={onChange} />);
+    const input = screen.getByLabelText(/Public Key/i);
+    fireEvent.change(input, { target: { value: 'abc' } });
+    fireEvent.blur(input);
+    expect(onChange).toHaveBeenCalledWith(null);
+    expect(screen.getByText(/Could not decode as valid JWK/i)).toBeInTheDocument();
+  });
+
+  it('accepts a valid base64url-encoded JWK and emits the full DID', () => {
+    const onChange = vi.fn();
+    render(<DidJwkInput onChange={onChange} />);
+    const input = screen.getByLabelText(/Public Key/i);
+    fireEvent.change(input, { target: { value: VALID_JWK } });
+    fireEvent.blur(input);
+    expect(onChange).toHaveBeenCalledWith(`did:jwk:${VALID_JWK}`);
+    expect(screen.getByText(/Valid JWK format/i)).toBeInTheDocument();
+    expect(screen.getByText(`did:jwk:${VALID_JWK}`)).toBeInTheDocument();
+  });
+
+  it('renders an external error when provided', () => {
+    render(<DidJwkInput value={`did:jwk:${VALID_JWK}`} onChange={vi.fn()} error="Something is wrong" />);
+    expect(screen.getByText('Something is wrong')).toBeInTheDocument();
+  });
+});

--- a/tests/components/form-field.test.tsx
+++ b/tests/components/form-field.test.tsx
@@ -77,19 +77,19 @@ describe('FormField', () => {
     expect(handleChange).toHaveBeenCalledWith('about me');
   });
 
-  it('applies error border class to textarea when error is provided', () => {
+  it('applies error class to textarea when error is provided', () => {
     render(
       <FormField label="Bio" name="bio" type="textarea" value="" onChange={() => {}} error="Required" />
     );
     const textarea = screen.getByLabelText(/^Bio/);
-    expect(textarea).toHaveClass('border-red-500');
+    expect(textarea).toHaveClass('field-error');
   });
 
-  it('applies error border class to array input when error is provided', () => {
+  it('applies error class to array input when error is provided', () => {
     render(
       <FormField label="Tags" name="tags" type="array" value={[]} onChange={() => {}} error="Invalid" />
     );
     const input = screen.getByLabelText(/^Tags/);
-    expect(input).toHaveClass('border-red-500');
+    expect(input).toHaveClass('field-error');
   });
 }); 

--- a/tests/components/header.test.tsx
+++ b/tests/components/header.test.tsx
@@ -1,62 +1,142 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import { expect, vi } from 'vitest';
-import { Header } from '@/components/header';
-import { act } from 'react'
+import React from "react"
+import { render, screen, waitFor } from "@testing-library/react"
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { Header } from "@/components/header"
 
-vi.mock('next/navigation', () => ({
-  usePathname: () => '/',
-}));
-vi.mock('next/image', () => ({
-  __esModule: true,
-  default: (props: any) => <img {...props} />,
-}));
-vi.mock('@/lib/blockchain', () => ({
-  useWallet: () => ({ isConnected: false, isChainSupported: true, chain: null }),
-}));
-vi.mock('thirdweb/react', () => ({
-  useActiveAccount: () => null,
-  useActiveWallet: () => null,
-  useActiveWalletChain: () => null,
-  useSwitchActiveWalletChain: () => null,
-  ConnectButton: () => <button>Connect Wallet</button>,
-}));
-vi.mock('@/app/client', () => ({ client: {} }));
+const mocks = vi.hoisted(() => ({
+  pathname: "/",
+  queryString: "",
+  replace: vi.fn(),
+  openAuthDialog: vi.fn(),
+  closeAuthDialog: vi.fn(),
+  authDialog: { open: false, mode: "chooser" as const },
+  session: null as { account?: { displayName?: string }; wallet?: { did?: string } } | null,
+}))
 
-describe('Header', () => {
-  it('renders logo and navigation links', async () => {
-    await act(async () => {
-      render(<Header />);
-    });
-    expect(screen.getByAltText('OMA3 Logo')).not.toBeNull();
-    expect(screen.getByText('Home')).not.toBeNull();
-    expect(screen.getByText('Registry')).not.toBeNull();
-    expect(screen.getByText('Docs')).not.toBeNull();
-  });
+vi.mock("next/navigation", () => ({
+  usePathname: () => mocks.pathname,
+  useRouter: () => ({ replace: mocks.replace }),
+  useSearchParams: () => new URLSearchParams(mocks.queryString),
+}))
 
-  it('renders My Attestations nav link pointing to /dashboard', async () => {
-    await act(async () => {
-      render(<Header />);
-    });
-    const link = screen.getByText('My Attestations');
-    expect(link).not.toBeNull();
-    expect(link.closest('a')).toHaveAttribute('href', '/dashboard');
-  });
+vi.mock("@/components/backend-session-provider", () => ({
+  useBackendSession: () => ({
+    session: mocks.session,
+    authDialog: mocks.authDialog,
+    closeAuthDialog: mocks.closeAuthDialog,
+    openAuthDialog: mocks.openAuthDialog,
+  }),
+}))
 
-  it('renders wallet connect button', async () => {
-    await act(async () => {
-      render(<Header />);
-    });
-    expect(screen.getByText(/connect wallet/i)).not.toBeNull();
-  });
+vi.mock("@/components/auth-entry-dialog", () => ({
+  AuthEntryDialog: ({ request }: { request: { mode: string } }) => (
+    <div data-testid="auth-entry-dialog">Auth dialog ({request.mode})</div>
+  ),
+}))
 
-  it('shows network warning when not supported', async () => {
-    vi.mock('@/lib/blockchain', () => ({
-      useWallet: () => ({ isConnected: true, isChainSupported: false, chain: null }),
-    }));
-    await act(async () => {
-      render(<Header />);
-    });
-    expect(screen.getByText(/wrong network/i)).not.toBeNull();
-  });
-}); 
+vi.mock("@/components/review-widget-modal", () => ({
+  ReviewWidgetModal: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="review-widget-modal">Review widget</div> : null,
+}))
+
+describe("Header", () => {
+  beforeEach(() => {
+    mocks.pathname = "/"
+    mocks.queryString = ""
+    mocks.replace.mockReset()
+    mocks.openAuthDialog.mockReset()
+    mocks.closeAuthDialog.mockReset()
+    mocks.authDialog = { open: false, mode: "chooser" }
+    mocks.session = null
+  })
+
+  it("renders OMATrust brand and current navigation links", () => {
+    render(<Header />)
+    expect(screen.getByText("OMATrust")).toBeInTheDocument()
+    expect(screen.getByText("Activity")).toBeInTheDocument()
+    expect(screen.getByText("Dashboard")).toBeInTheDocument()
+    expect(screen.getByText("Docs")).toBeInTheDocument()
+  })
+
+  it("renders Docs link with external attributes", () => {
+    render(<Header />)
+    const docsLink = screen.getByRole("link", { name: "Docs" })
+    expect(docsLink).toHaveAttribute("href", "https://docs.omatrust.org/")
+    expect(docsLink).toHaveAttribute("target", "_blank")
+    expect(docsLink).toHaveAttribute("rel", "noopener noreferrer")
+  })
+
+  it("renders Review button when signed in (alongside account link)", () => {
+    mocks.session = { account: { displayName: "Alice" } }
+    render(<Header />)
+    expect(screen.getByRole("button", { name: /review/i })).toBeInTheDocument()
+  })
+
+  it("shows Sign In when no backend session is present", () => {
+    render(<Header />)
+    expect(screen.getByRole("button", { name: "Sign In" })).toBeInTheDocument()
+  })
+
+  it("shows account link when session exists", () => {
+    mocks.session = { account: { displayName: "Alice" }, wallet: { did: "did:pkh:eip155:1:0xabc" } }
+    render(<Header />)
+
+    const accountLink = screen.getByRole("link", { name: "Alice" })
+    expect(accountLink).toHaveAttribute("href", "/account")
+  })
+
+  it("opens chooser auth dialog from ?action=signin and cleans URL", async () => {
+    mocks.queryString = "action=signin&foo=bar"
+    render(<Header />)
+
+    await waitFor(() => {
+      expect(mocks.openAuthDialog).toHaveBeenCalledWith(
+        expect.objectContaining({ mode: "chooser" })
+      )
+      expect(mocks.replace).toHaveBeenCalledWith("/?foo=bar", { scroll: false })
+    })
+  })
+
+  it("opens signup auth dialog from ?action=signup", async () => {
+    mocks.queryString = "action=signup"
+    render(<Header />)
+
+    await waitFor(() => {
+      expect(mocks.openAuthDialog).toHaveBeenCalledWith(
+        expect.objectContaining({ mode: "signup" })
+      )
+      expect(mocks.replace).toHaveBeenCalledWith("/", { scroll: false })
+    })
+  })
+
+  it("forwards known hint message when opening auth dialog", async () => {
+    mocks.queryString = "action=signin&hint=no-account"
+    render(<Header />)
+
+    await waitFor(() => {
+      expect(mocks.openAuthDialog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mode: "chooser",
+          hintMessage: expect.stringContaining("No account"),
+        })
+      )
+    })
+  })
+
+  it("does not open auth dialog from ?action=signin when already signed in", async () => {
+    mocks.queryString = "action=signin"
+    mocks.session = { account: { displayName: "Alice" } }
+    render(<Header />)
+
+    await waitFor(() => {
+      expect(mocks.openAuthDialog).not.toHaveBeenCalled()
+      expect(mocks.replace).toHaveBeenCalledWith("/", { scroll: false })
+    })
+  })
+
+  it("renders AuthEntryDialog when backend auth dialog is open", () => {
+    mocks.authDialog = { open: true, mode: "signin" }
+    render(<Header />)
+    expect(screen.getByTestId("auth-entry-dialog")).toHaveTextContent("Auth dialog (signin)")
+  })
+})

--- a/tests/components/home/LatestTrustProfiles.test.tsx
+++ b/tests/components/home/LatestTrustProfiles.test.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+const mockUseWallet = vi.fn();
+const mockGetLatest = vi.fn();
+
+vi.mock('@/lib/blockchain', () => ({
+  useWallet: () => mockUseWallet(),
+}));
+
+vi.mock('@/lib/attestation-queries', () => ({
+  getLatestAttestationsWithMetadata: (...args: unknown[]) => mockGetLatest(...args),
+}));
+
+import { LatestTrustProfiles } from '@/components/home/LatestTrustProfiles';
+
+function att(overrides: Record<string, unknown> = {}) {
+  return {
+    uid: '0x' + Math.random().toString(16).slice(2).padEnd(64, '0'),
+    schemaId: 'key-binding',
+    recipient: '0x9999999999999999999999999999999999999999',
+    decodedData: { subject: 'did:web:example.com' },
+    time: 1000,
+    revocationTime: 0,
+    ...overrides,
+  };
+}
+
+describe('LatestTrustProfiles', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseWallet.mockReturnValue({ chainId: 66238 });
+  });
+
+  it('builds profiles from pre-fetched data without fetching', async () => {
+    render(<LatestTrustProfiles data={[att()] as never} />);
+    await waitFor(() => {
+      expect(screen.getByText('example.com')).toBeInTheDocument();
+    });
+    expect(mockGetLatest).not.toHaveBeenCalled();
+  });
+
+  it('marks the signing-key indicator for key-binding attestations', async () => {
+    const { container } = render(<LatestTrustProfiles data={[att({ schemaId: 'key-binding' })] as never} />);
+    await screen.findByText('example.com');
+    // The "Signing key" indicator should be checked (CheckCircle2 has text-primary).
+    expect(screen.getByText('Signing key')).toBeInTheDocument();
+    expect(container.querySelector('svg.text-primary')).toBeTruthy();
+  });
+
+  it('extracts the domain from a did:web subject and truncates raw addresses', async () => {
+    render(
+      <LatestTrustProfiles
+        data={[
+          att({ schemaId: 'key-binding', decodedData: { subject: 'did:web:foo.example.org' }, time: 2 }),
+          att({ schemaId: 'controller-witness', decodedData: undefined, recipient: '0xabcdefabcdefabcdefabcdefabcdefabcdef1234', time: 1 }),
+        ] as never}
+      />
+    );
+    await waitFor(() => {
+      expect(screen.getByText('foo.example.org')).toBeInTheDocument();
+      expect(screen.getByText('0xabcd...1234')).toBeInTheDocument();
+    });
+  });
+
+  it('ignores revoked and non-trust attestations', async () => {
+    render(
+      <LatestTrustProfiles
+        data={[
+          att({ schemaId: 'user-review', decodedData: { subject: 'did:web:ignored.com' } }),
+          att({ schemaId: 'key-binding', decodedData: { subject: 'did:web:revoked.com' }, revocationTime: 123 }),
+          att({ schemaId: 'key-binding', decodedData: { subject: 'did:web:kept.com' } }),
+        ] as never}
+      />
+    );
+    await waitFor(() => {
+      expect(screen.getByText('kept.com')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('ignored.com')).not.toBeInTheDocument();
+    expect(screen.queryByText('revoked.com')).not.toBeInTheDocument();
+  });
+
+  it('respects the limit prop', async () => {
+    render(
+      <LatestTrustProfiles
+        limit={1}
+        data={[
+          att({ schemaId: 'key-binding', decodedData: { subject: 'did:web:a.com' }, time: 5 }),
+          att({ schemaId: 'key-binding', decodedData: { subject: 'did:web:b.com' }, time: 3 }),
+        ] as never}
+      />
+    );
+    await waitFor(() => {
+      expect(screen.getByText('a.com')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('b.com')).not.toBeInTheDocument();
+  });
+
+  it('fetches attestations when no data prop is provided', async () => {
+    mockGetLatest.mockResolvedValue([att({ schemaId: 'key-binding', decodedData: { subject: 'did:web:fetched.com' } })]);
+    render(<LatestTrustProfiles />);
+    await waitFor(() => {
+      expect(screen.getByText('fetched.com')).toBeInTheDocument();
+    });
+    expect(mockGetLatest).toHaveBeenCalledWith(66238, 100);
+  });
+
+  it('shows an error message when the fetch fails', async () => {
+    mockGetLatest.mockRejectedValue(new Error('network down'));
+    render(<LatestTrustProfiles />);
+    await waitFor(() => {
+      expect(screen.getByText(/Error loading trust profiles: network down/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows an empty state when there are no trust profiles', async () => {
+    render(<LatestTrustProfiles data={[] as never} />);
+    await waitFor(() => {
+      expect(screen.getByText(/No trust profiles found yet/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/tests/components/pre-alpha-banner.test.tsx
+++ b/tests/components/pre-alpha-banner.test.tsx
@@ -75,16 +75,30 @@ describe('PreAlphaBanner', () => {
 
   it('has correct styling classes', () => {
     render(<PreAlphaBanner />);
-    
+
     const banner = screen.getByText(/Pre-Alpha Preview/i).closest('div')?.parentElement;
-    expect(banner).toHaveClass('bg-yellow-100', 'text-black', 'px-4', 'py-3', 'shadow-sm', 'border-b');
+    expect(banner).toHaveClass(
+      'border-b',
+      'border-warning/30',
+      'bg-warning/12',
+      'text-warning-foreground',
+      'px-4',
+      'py-3',
+      'shadow-sm',
+    );
   });
 
   it('dismiss button has correct styling', () => {
     render(<PreAlphaBanner />);
-    
+
     const dismissButton = screen.getByRole('button', { name: /dismiss banner/i });
-    expect(dismissButton).toHaveClass('ml-4', 'p-1', 'hover:bg-yellow-200', 'rounded-full', 'transition-colors');
+    expect(dismissButton).toHaveClass(
+      'ml-4',
+      'p-1',
+      'rounded-full',
+      'transition-colors',
+      'hover:bg-warning/15',
+    );
   });
 
   it('handles multiple dismissals gracefully', () => {

--- a/tests/components/providers.test.tsx
+++ b/tests/components/providers.test.tsx
@@ -1,14 +1,33 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { expect, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { Providers } from '@/components/providers';
 
 vi.mock('thirdweb/react', () => ({
-  ThirdwebProvider: ({ children }: { children: React.ReactNode }) => <div data-testid="thirdweb-provider">{children}</div>,
+  ThirdwebProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="thirdweb-provider">{children}</div>
+  ),
+  useActiveAccount: () => null,
+  useActiveWallet: () => null,
+  useActiveWalletChain: () => null,
+  useAutoConnect: () => ({ isLoading: false }),
+  useDisconnect: () => ({ disconnect: vi.fn() }),
+  useConnect: () => ({ connect: vi.fn(), isConnecting: false, error: null }),
+  useSwitchActiveWalletChain: () => vi.fn(),
+  ConnectButton: () => <button>Connect Wallet</button>,
 }));
+
 vi.mock('@tanstack/react-query', () => ({
-  QueryClientProvider: ({ children }: { children: React.ReactNode }) => <div data-testid="query-client-provider">{children}</div>,
+  QueryClientProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="query-client-provider">{children}</div>
+  ),
   QueryClient: class {},
+}));
+
+vi.mock('@/components/backend-session-provider', () => ({
+  BackendSessionProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="backend-session-provider">{children}</div>
+  ),
 }));
 
 describe('Providers', () => {
@@ -18,8 +37,25 @@ describe('Providers', () => {
         <div data-testid="child">Child</div>
       </Providers>
     );
-    expect(screen.getByTestId('thirdweb-provider')).not.toBeNull();
-    expect(screen.getByTestId('query-client-provider')).not.toBeNull();
-    expect(screen.getByTestId('child')).not.toBeNull();
+    expect(screen.getByTestId('query-client-provider')).toBeInTheDocument();
+    expect(screen.getByTestId('thirdweb-provider')).toBeInTheDocument();
+    expect(screen.getByTestId('backend-session-provider')).toBeInTheDocument();
+    expect(screen.getByTestId('child')).toBeInTheDocument();
+  });
+
+  it('nests providers in the expected order (query > thirdweb > backend > children)', () => {
+    render(
+      <Providers>
+        <div data-testid="child">Child</div>
+      </Providers>
+    );
+    const queryProvider = screen.getByTestId('query-client-provider');
+    const thirdwebProvider = screen.getByTestId('thirdweb-provider');
+    const backendProvider = screen.getByTestId('backend-session-provider');
+    const child = screen.getByTestId('child');
+
+    expect(queryProvider).toContainElement(thirdwebProvider);
+    expect(thirdwebProvider).toContainElement(backendProvider);
+    expect(backendProvider).toContainElement(child);
   });
 }); 

--- a/tests/components/review-widget-modal.test.tsx
+++ b/tests/components/review-widget-modal.test.tsx
@@ -1,0 +1,249 @@
+import React from "react"
+import { render, screen, waitFor } from "@testing-library/react"
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { ReviewWidgetModal } from "@/components/review-widget-modal"
+
+const mocks = vi.hoisted(() => {
+  return {
+    account: { address: "0xabc123" } as { address: string } | null,
+    createSigningBridge: vi.fn(),
+    signTypedData: vi.fn().mockResolvedValue("0xsigned"),
+    destroy: vi.fn(),
+  }
+})
+
+vi.mock("thirdweb/react", () => ({
+  useActiveAccount: () => mocks.account,
+}))
+
+vi.mock("thirdweb/adapters/ethers6", () => ({
+  ethers6Adapter: {
+    signer: {
+      toEthers: () => ({
+        signTypedData: mocks.signTypedData,
+      }),
+    },
+  },
+}))
+
+vi.mock("@/app/client", () => ({
+  client: {},
+}))
+
+vi.mock("@/lib/blockchain", () => ({
+  getActiveThirdwebChain: () => ({ id: 66238 }),
+}))
+
+vi.mock(
+  "@oma3/omatrust/widgets",
+  () => ({
+    createSigningBridge: (...args: unknown[]) => mocks.createSigningBridge(...args),
+  }),
+  { virtual: true }
+)
+
+describe("ReviewWidgetModal", () => {
+  beforeEach(() => {
+    mocks.account = { address: "0xabc123" }
+    mocks.createSigningBridge.mockReset()
+    mocks.signTypedData.mockClear()
+    mocks.destroy.mockReset()
+    mocks.createSigningBridge.mockResolvedValue({ destroy: mocks.destroy })
+  })
+
+  it("renders nothing when modal is closed", () => {
+    const { container } = render(
+      <ReviewWidgetModal open={false} onOpenChange={() => {}} />
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it("renders iframe with connected wallet query param", () => {
+    render(<ReviewWidgetModal open onOpenChange={() => {}} />)
+    const iframe = screen.getByTitle("OMATrust Review Widget")
+    expect(iframe).toBeInTheDocument()
+    expect(iframe).toHaveAttribute("src", expect.stringContaining("wallet=0xabc123"))
+  })
+
+  it("uses NEXT_PUBLIC_WIDGET_BASE_URL override for iframe src", async () => {
+    vi.stubEnv("NEXT_PUBLIC_WIDGET_BASE_URL", "https://preview.widgets.omatrust.org")
+    try {
+      vi.resetModules()
+      const { ReviewWidgetModal: EnvOverrideWidget } = await import("@/components/review-widget-modal")
+      render(<EnvOverrideWidget open onOpenChange={() => {}} />)
+      const iframe = screen.getByTitle("OMATrust Review Widget")
+      expect(iframe).toHaveAttribute(
+        "src",
+        expect.stringContaining("https://preview.widgets.omatrust.org/widgets/reviews/embed")
+      )
+    } finally {
+      vi.unstubAllEnvs()
+      vi.resetModules()
+    }
+  })
+
+  it("passes env-based devOriginOverride into createSigningBridge", async () => {
+    vi.stubEnv("NEXT_PUBLIC_WIDGET_BASE_URL", "https://preview.widgets.omatrust.org")
+    try {
+      vi.resetModules()
+      const { ReviewWidgetModal: EnvOverrideWidget } = await import("@/components/review-widget-modal")
+      render(<EnvOverrideWidget open onOpenChange={() => {}} />)
+
+      await waitFor(() => {
+        expect(mocks.createSigningBridge).toHaveBeenCalledWith(
+          expect.objectContaining({
+            devOriginOverride: "https://preview.widgets.omatrust.org",
+          })
+        )
+      })
+    } finally {
+      vi.unstubAllEnvs()
+      vi.resetModules()
+    }
+  })
+
+  it("creates signing bridge on open and destroys it on unmount", async () => {
+    const { unmount } = render(<ReviewWidgetModal open onOpenChange={() => {}} />)
+
+    await waitFor(() => {
+      expect(mocks.createSigningBridge).toHaveBeenCalledWith(
+        expect.objectContaining({
+          iframeId: "omatrust-widget",
+          signTypedData: expect.any(Function),
+        })
+      )
+    })
+
+    unmount()
+
+    expect(mocks.destroy).toHaveBeenCalledTimes(1)
+  })
+
+  it("closes modal when widget sends omatrust:close message", async () => {
+    const onOpenChange = vi.fn()
+    render(<ReviewWidgetModal open onOpenChange={onOpenChange} />)
+
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data: { type: "omatrust:close" },
+      })
+    )
+
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(false)
+    })
+  })
+
+  it("does not create bridge when no active account", () => {
+    mocks.account = null
+    render(<ReviewWidgetModal open onOpenChange={() => {}} />)
+    expect(mocks.createSigningBridge).not.toHaveBeenCalled()
+  })
+
+  it("omits wallet query param when account has no address", () => {
+    mocks.account = {} as { address?: string }
+    render(<ReviewWidgetModal open onOpenChange={() => {}} />)
+    const iframe = screen.getByTitle("OMATrust Review Widget")
+    const src = iframe.getAttribute("src") ?? ""
+    expect(src).not.toContain("wallet=")
+  })
+
+  it("destroys bridge when modal closes", async () => {
+    const onOpenChange = vi.fn()
+    const { rerender } = render(
+      <ReviewWidgetModal open onOpenChange={onOpenChange} />
+    )
+
+    await waitFor(() => {
+      expect(mocks.createSigningBridge).toHaveBeenCalled()
+    })
+
+    rerender(<ReviewWidgetModal open={false} onOpenChange={onOpenChange} />)
+
+    await waitFor(() => {
+      expect(mocks.destroy).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it("recreates bridge on reopen and cleans up prior instance", async () => {
+    const onOpenChange = vi.fn()
+    const { rerender } = render(
+      <ReviewWidgetModal open onOpenChange={onOpenChange} />
+    )
+
+    await waitFor(() => {
+      expect(mocks.createSigningBridge).toHaveBeenCalledTimes(1)
+    })
+
+    rerender(<ReviewWidgetModal open={false} onOpenChange={onOpenChange} />)
+    await waitFor(() => {
+      expect(mocks.destroy).toHaveBeenCalledTimes(1)
+    })
+
+    rerender(<ReviewWidgetModal open onOpenChange={onOpenChange} />)
+    await waitFor(() => {
+      expect(mocks.createSigningBridge).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  it("forwards typed-data signing to the ethers signer from the bridge", async () => {
+    render(<ReviewWidgetModal open onOpenChange={() => {}} />)
+
+    await waitFor(() => {
+      expect(mocks.createSigningBridge).toHaveBeenCalled()
+    })
+
+    const bridgeConfig = mocks.createSigningBridge.mock.calls[0][0] as {
+      signTypedData: (
+        domain: Record<string, unknown>,
+        types: Record<string, unknown>,
+        message: Record<string, unknown>
+      ) => Promise<string>
+    }
+
+    const domain = { name: "Test", version: "1" }
+    const types = { Mail: [{ name: "contents", type: "string" }] }
+    const message = { contents: "hello" }
+
+    await bridgeConfig.signTypedData(domain, types, message)
+
+    expect(mocks.signTypedData).toHaveBeenCalledWith(domain, types, message)
+  })
+
+  it("does not close on unrelated postMessage payloads", () => {
+    const onOpenChange = vi.fn()
+    render(<ReviewWidgetModal open onOpenChange={onOpenChange} />)
+
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        data: { type: "something-else" },
+      })
+    )
+
+    expect(onOpenChange).not.toHaveBeenCalled()
+  })
+
+  it("exposes an accessible dialog title for screen readers", () => {
+    render(<ReviewWidgetModal open onOpenChange={() => {}} />)
+    expect(
+      screen.getByText("Review OMATrust Reputation")
+    ).toBeInTheDocument()
+  })
+
+  it("logs bridge creation failures", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {})
+    const error = new Error("bridge failure")
+    mocks.createSigningBridge.mockRejectedValueOnce(error)
+
+    render(<ReviewWidgetModal open onOpenChange={() => {}} />)
+
+    await waitFor(() => {
+      expect(consoleError).toHaveBeenCalledWith(
+        "[ReviewWidgetModal] Bridge creation failed:",
+        error
+      )
+    })
+
+    consoleError.mockRestore()
+  })
+})

--- a/tests/components/star-rating.test.tsx
+++ b/tests/components/star-rating.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { StarRating, getRatingValue } from '@/components/star-rating';
+
+describe('getRatingValue', () => {
+  it('rounds numeric values to the nearest integer', () => {
+    expect(getRatingValue(3.4)).toBe(3);
+    expect(getRatingValue(3.6)).toBe(4);
+  });
+
+  it('parses numeric strings', () => {
+    expect(getRatingValue('4')).toBe(4);
+    expect(getRatingValue('2.5')).toBe(3); // 2.5 rounds to 3 (half-up)
+  });
+
+  it('converts bigint values', () => {
+    expect(getRatingValue(5n)).toBe(5);
+  });
+
+  it('clamps to the [0, max] range', () => {
+    expect(getRatingValue(9)).toBe(5);
+    expect(getRatingValue(-3)).toBe(0);
+    expect(getRatingValue(9, 10)).toBe(9);
+  });
+
+  it('returns null for non-finite or non-numeric values', () => {
+    expect(getRatingValue(null)).toBeNull();
+    expect(getRatingValue(undefined)).toBeNull();
+    expect(getRatingValue('not-a-number')).toBeNull();
+    expect(getRatingValue(NaN)).toBeNull();
+    expect(getRatingValue(Infinity)).toBeNull();
+  });
+});
+
+describe('StarRating', () => {
+  it('renders a dash when the value cannot be parsed', () => {
+    render(<StarRating value={null} />);
+    expect(screen.getByText('-')).toBeInTheDocument();
+  });
+
+  it('exposes an accessible label and title for a valid rating', () => {
+    render(<StarRating value={4} />);
+    expect(screen.getByLabelText('4 out of 5 stars')).toBeInTheDocument();
+    expect(screen.getByTitle('4/5')).toBeInTheDocument();
+  });
+
+  it('renders `max` star icons', () => {
+    const { container } = render(<StarRating value={3} max={5} />);
+    expect(container.querySelectorAll('svg')).toHaveLength(5);
+  });
+
+  it('respects a custom max in the accessible label', () => {
+    render(<StarRating value={7} max={10} />);
+    expect(screen.getByLabelText('7 out of 10 stars')).toBeInTheDocument();
+  });
+});

--- a/tests/components/subject-confirmation-dialog.test.tsx
+++ b/tests/components/subject-confirmation-dialog.test.tsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+const mockVerifySubjectOwnership = vi.fn();
+const mockCreateSubject = vi.fn();
+
+vi.mock('@/lib/omatrust-backend', () => {
+  class BackendApiError extends Error {
+    status: number;
+    code?: string;
+    details?: string;
+    constructor(message: string, status: number, code?: string, details?: string) {
+      super(message);
+      this.name = 'BackendApiError';
+      this.status = status;
+      this.code = code;
+      this.details = details;
+    }
+  }
+  return {
+    BackendApiError,
+    verifySubjectOwnership: (...args: unknown[]) => mockVerifySubjectOwnership(...args),
+    createSubject: (...args: unknown[]) => mockCreateSubject(...args),
+  };
+});
+
+vi.mock('@/components/did-web-input', () => ({
+  DidWebInput: ({ value, onChange }: { value: string; onChange: (v: string | null) => void }) => (
+    <input
+      data-testid="did-web-input"
+      value={value}
+      onChange={(e) => onChange(e.target.value || null)}
+    />
+  ),
+}));
+
+vi.mock('@/components/caip10-input', () => ({
+  Caip10Input: ({ value, onChange }: { value: string; onChange: (v: string | null) => void }) => (
+    <input data-testid="caip10-input" value={value} onChange={(e) => onChange(e.target.value || null)} />
+  ),
+}));
+
+import { SubjectConfirmationDialog } from '@/components/subject-confirmation-dialog';
+import { BackendApiError } from '@/lib/omatrust-backend';
+
+const WALLET_DID = 'did:pkh:eip155:1:0xabc';
+
+function setup(overrides: Partial<React.ComponentProps<typeof SubjectConfirmationDialog>> = {}) {
+  const onOpenChange = vi.fn();
+  const onSubjectCreated = vi.fn();
+  render(
+    <SubjectConfirmationDialog
+      open
+      onOpenChange={onOpenChange}
+      walletDid={WALLET_DID}
+      existingSubjectDids={[]}
+      onSubjectCreated={onSubjectCreated}
+      {...overrides}
+    />
+  );
+  return { onOpenChange, onSubjectCreated };
+}
+
+describe('SubjectConfirmationDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the dialog title and a disabled Verify button initially', () => {
+    setup();
+    expect(screen.getByText('Verify Subject Ownership')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Verify' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled();
+  });
+
+  it('enables Verify once a subject identifier is entered', () => {
+    setup();
+    fireEvent.change(screen.getByTestId('did-web-input'), { target: { value: 'did:web:example.com' } });
+    expect(screen.getByRole('button', { name: 'Verify' })).toBeEnabled();
+  });
+
+  it('blocks verifying a subject already attached to the account', () => {
+    setup({ existingSubjectDids: ['did:web:example.com'] });
+    fireEvent.change(screen.getByTestId('did-web-input'), { target: { value: 'did:web:example.com' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Verify' }));
+    expect(screen.getByText(/already attached to your account/i)).toBeInTheDocument();
+    expect(mockVerifySubjectOwnership).not.toHaveBeenCalled();
+  });
+
+  it('shows a failure message when ownership verification does not succeed', async () => {
+    mockVerifySubjectOwnership.mockResolvedValue({ ok: false, error: 'No TXT record found' });
+    setup();
+    fireEvent.change(screen.getByTestId('did-web-input'), { target: { value: 'did:web:example.com' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Verify' }));
+    await waitFor(() => {
+      expect(screen.getByText('No TXT record found')).toBeInTheDocument();
+    });
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled();
+  });
+
+  it('verifies ownership then submits the new subject', async () => {
+    mockVerifySubjectOwnership.mockResolvedValue({ ok: true, method: 'dns' });
+    mockCreateSubject.mockResolvedValue({ subject: { id: 's1', canonicalDid: 'did:web:example.com' } });
+    const { onOpenChange, onSubjectCreated } = setup();
+
+    fireEvent.change(screen.getByTestId('did-web-input'), { target: { value: 'did:web:example.com' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Verify' }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Ownership verified via DNS TXT/i)).toBeInTheDocument();
+    });
+
+    const submit = screen.getByRole('button', { name: 'Submit' });
+    await waitFor(() => expect(submit).toBeEnabled());
+    fireEvent.click(submit);
+
+    await waitFor(() => {
+      expect(mockCreateSubject).toHaveBeenCalledWith({ did: 'did:web:example.com' });
+    });
+    expect(onSubjectCreated).toHaveBeenCalledWith({ id: 's1', canonicalDid: 'did:web:example.com' });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('surfaces a 500-level verification service error', async () => {
+    mockVerifySubjectOwnership.mockRejectedValue(new BackendApiError('boom', 503));
+    setup();
+    fireEvent.change(screen.getByTestId('did-web-input'), { target: { value: 'did:web:example.com' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Verify' }));
+    await waitFor(() => {
+      expect(screen.getByText(/problem with the verification service/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/tests/config/attestation-services.test.ts
+++ b/tests/config/attestation-services.test.ts
@@ -5,7 +5,6 @@ import {
   EAS_CONFIG,
   ATTESTATION_SERVICES,
   ATTESTATION_QUERY_CONFIG,
-  CONTROLLER_WITNESS_CONFIG,
   getAttestationService,
   getServicesForChain,
   getContractAddress,
@@ -112,23 +111,6 @@ describe('attestation-services config', () => {
         expect(typeof service.contracts).toBe('object');
         expect(Array.isArray(service.features)).toBe(true);
       });
-    });
-  });
-
-  describe('CONTROLLER_WITNESS_CONFIG', () => {
-    it('has grace period for key-binding and linked-identifier schemas', () => {
-      expect(CONTROLLER_WITNESS_CONFIG.graceSchemaIds).toContain('key-binding');
-      expect(CONTROLLER_WITNESS_CONFIG.graceSchemaIds).toContain('linked-identifier');
-      expect(CONTROLLER_WITNESS_CONFIG.graceSchemaIds).toHaveLength(2);
-    });
-
-    it('has a positive grace period in seconds', () => {
-      expect(CONTROLLER_WITNESS_CONFIG.graceSeconds).toBeGreaterThan(0);
-      expect(typeof CONTROLLER_WITNESS_CONFIG.graceSeconds).toBe('number');
-    });
-
-    it('grace period is 120 seconds (2 minutes)', () => {
-      expect(CONTROLLER_WITNESS_CONFIG.graceSeconds).toBe(120);
     });
   });
 

--- a/tests/config/index.test.ts
+++ b/tests/config/index.test.ts
@@ -4,9 +4,13 @@ import * as config from '@/config/index';
 describe('config index', () => {
   it('exports schemas', () => {
     expect(config.certificationSchema).toBeDefined();
-    expect(config.endorsementSchema).toBeDefined();
     expect(config.linkedIdentifierSchema).toBeDefined();
     expect(config.userReviewSchema).toBeDefined();
+    expect(config.keyBindingSchema).toBeDefined();
+    expect(config.controllerWitnessSchema).toBeDefined();
+    expect(config.userReviewResponseSchema).toBeDefined();
+    expect(config.securityAssessmentSchema).toBeDefined();
+    expect(config.commonSchema).toBeDefined();
     expect(config.getSchema).toBeDefined();
     expect(config.getSchemaIds).toBeDefined();
     expect(config.getAllSchemas).toBeDefined();
@@ -22,26 +26,34 @@ describe('config index', () => {
   });
 
   it('exports all expected functions and objects', () => {
-    // Verify that all expected exports are available
     const expectedExports = [
       'certificationSchema',
-      'endorsementSchema', 
+      'commonSchema',
+      'controllerWitnessSchema',
+      'keyBindingSchema',
       'linkedIdentifierSchema',
+      'securityAssessmentSchema',
+      'userReviewResponseSchema',
       'userReviewSchema',
       'getSchema',
       'getSchemaIds',
       'getAllSchemas',
       'BAS_CONFIG',
+      'EAS_CONFIG',
       'ATTESTATION_SERVICES',
       'getAttestationService',
       'getServicesForChain',
       'getContractAddress',
       'getAllServiceIds'
     ];
-    
+
     expectedExports.forEach(exportName => {
       expect(config).toHaveProperty(exportName);
     });
+  });
+
+  it('does not export the removed endorsement schema', () => {
+    expect((config as Record<string, unknown>).endorsementSchema).toBeUndefined();
   });
 
   it('exports functions are callable', () => {

--- a/tests/config/schemas.test.ts
+++ b/tests/config/schemas.test.ts
@@ -3,7 +3,6 @@ import {
   certificationSchema,
   commonSchema,
   controllerWitnessSchema,
-  endorsementSchema,
   keyBindingSchema,
   linkedIdentifierSchema,
   securityAssessmentSchema,
@@ -19,11 +18,10 @@ import {
 
 describe('schemas config', () => {
   describe('schema exports', () => {
-    it('exports all nine schemas', () => {
+    it('exports all eight schemas', () => {
       expect(certificationSchema).toBeDefined();
       expect(commonSchema).toBeDefined();
       expect(controllerWitnessSchema).toBeDefined();
-      expect(endorsementSchema).toBeDefined();
       expect(keyBindingSchema).toBeDefined();
       expect(linkedIdentifierSchema).toBeDefined();
       expect(securityAssessmentSchema).toBeDefined();
@@ -69,7 +67,6 @@ describe('schemas config', () => {
       const expectedDeployedUIDs: Record<string, string> = {
         'certification': '0x2b0d1100f7943c0c2ea29e35c1286bd860fa752124e035cafb503bb83f234805',
         'controller-witness': '0xc81419f828755c0be2c49091dcad0887b5ca7342316dfffb4314aadbf8205090',
-        'endorsement': '0xb0cf93ef0f3feb858aa5d07a54f6589da5852883f378dfd0cae5315da1d679ac',
         'key-binding': '0x807b38ce9aa23fdde4457de01db9c5e8d6ec7c8feebee242e52be70847b7b966',
         'linked-identifier': '0x26e21911c55587925afee4b17839ab091e9829321b4a4e1658c497eb0088b453',
         'security-assessment': '0x67bcc2424e3721d56e85bb650c6aba8bf7f1711d9c9a434c3afae3a22d23eed7',
@@ -159,12 +156,6 @@ describe('schemas config', () => {
       expect(keyBindingSchema.revocable).toBe(true);
     });
 
-    it('has witness configuration for controller witness', () => {
-      expect(keyBindingSchema.witness).toBeDefined();
-      expect(keyBindingSchema.witness?.subjectField).toBe('subject');
-      expect(keyBindingSchema.witness?.controllerField).toBe('keyId');
-    });
-
     it('has keyId as required field', () => {
       const keyIdField = keyBindingSchema.fields.find(f => f.name === 'keyId');
       expect(keyIdField).toBeDefined();
@@ -202,12 +193,6 @@ describe('schemas config', () => {
       expect(linkedIdentifierSchema.revocable).toBe(true);
     });
 
-    it('has witness configuration for controller witness', () => {
-      expect(linkedIdentifierSchema.witness).toBeDefined();
-      expect(linkedIdentifierSchema.witness?.subjectField).toBe('subject');
-      expect(linkedIdentifierSchema.witness?.controllerField).toBe('linkedId');
-    });
-
     it('has linkedId as required field', () => {
       const linkedIdField = linkedIdentifierSchema.fields.find(f => f.name === 'linkedId');
       expect(linkedIdField).toBeDefined();
@@ -215,11 +200,12 @@ describe('schemas config', () => {
       expect(linkedIdField?.pattern).toBe('^did:[a-z0-9]+:.+$');
     });
 
-    it('has method as required field', () => {
+    it('has method as required enum field', () => {
       const methodField = linkedIdentifierSchema.fields.find(f => f.name === 'method');
       expect(methodField).toBeDefined();
       expect(methodField?.required).toBe(true);
-      expect(methodField?.type).toBe('string');
+      expect(methodField?.type).toBe('enum');
+      expect(methodField?.options).toEqual(['proof', 'manual']);
     });
   });
 
@@ -261,20 +247,6 @@ describe('schemas config', () => {
     });
   });
 
-  describe('endorsementSchema', () => {
-    it('has correct properties', () => {
-      expect(endorsementSchema.id).toBe('endorsement');
-      expect(endorsementSchema.title).toBe('Endorsement');
-      expect(endorsementSchema.description).toContain('lightweight');
-    });
-
-    it('has subject as required field', () => {
-      const subjectField = endorsementSchema.fields.find(field => field.name === 'subject');
-      expect(subjectField).toBeDefined();
-      expect(subjectField?.required).toBe(true);
-    });
-  });
-
   describe('userReviewSchema', () => {
     it('has correct properties', () => {
       expect(userReviewSchema.id).toBe('user-review');
@@ -288,25 +260,6 @@ describe('schemas config', () => {
       expect(ratingField?.type).toBe('enum');
       expect(ratingField?.options).toEqual([1, 2, 3, 4, 5]);
       expect(ratingField?.required).toBe(true);
-    });
-  });
-
-  describe('witness configuration', () => {
-    it('only key-binding and linked-identifier have witness config', () => {
-      const schemas = getAllSchemas();
-      const witnessSchemas = schemas.filter(s => s.witness);
-      expect(witnessSchemas).toHaveLength(2);
-      expect(witnessSchemas.map(s => s.id).sort()).toEqual(['key-binding', 'linked-identifier']);
-    });
-
-    it('witness config has correct shape', () => {
-      const witnessSchemas = getAllSchemas().filter(s => s.witness);
-      witnessSchemas.forEach(schema => {
-        expect(schema.witness).toHaveProperty('subjectField');
-        expect(schema.witness).toHaveProperty('controllerField');
-        expect(typeof schema.witness!.subjectField).toBe('string');
-        expect(typeof schema.witness!.controllerField).toBe('string');
-      });
     });
   });
 
@@ -327,15 +280,16 @@ describe('schemas config', () => {
 
     it('other schemas are not explicitly revocable', () => {
       expect(certificationSchema.revocable).toBeFalsy();
-      expect(endorsementSchema.revocable).toBeFalsy();
       expect(controllerWitnessSchema.revocable).toBeFalsy();
+      expect(userReviewSchema.revocable).toBeFalsy();
+      expect(userReviewResponseSchema.revocable).toBeFalsy();
+      expect(securityAssessmentSchema.revocable).toBeFalsy();
     });
   });
 
   describe('getSchema function', () => {
     it('returns schema for valid ID', () => {
       expect(getSchema('certification')).toBe(certificationSchema);
-      expect(getSchema('endorsement')).toBe(endorsementSchema);
       expect(getSchema('linked-identifier')).toBe(linkedIdentifierSchema);
       expect(getSchema('user-review')).toBe(userReviewSchema);
       expect(getSchema('controller-witness')).toBe(controllerWitnessSchema);
@@ -343,6 +297,10 @@ describe('schemas config', () => {
       expect(getSchema('security-assessment')).toBe(securityAssessmentSchema);
       expect(getSchema('common')).toBe(commonSchema);
       expect(getSchema('user-review-response')).toBe(userReviewResponseSchema);
+    });
+
+    it('returns undefined for the removed endorsement schema', () => {
+      expect(getSchema('endorsement')).toBeUndefined();
     });
 
     it('returns undefined for invalid ID', () => {
@@ -354,7 +312,7 @@ describe('schemas config', () => {
   describe('getSchemaIds function', () => {
     it('returns all schema IDs', () => {
       const ids = getSchemaIds();
-      expect(ids).toEqual(['certification', 'common', 'controller-witness', 'endorsement', 'key-binding', 'linked-identifier', 'security-assessment', 'user-review-response', 'user-review']);
+      expect(ids).toEqual(['certification', 'common', 'controller-witness', 'key-binding', 'linked-identifier', 'security-assessment', 'user-review-response', 'user-review']);
     });
 
     it('returns array of strings', () => {
@@ -369,11 +327,10 @@ describe('schemas config', () => {
   describe('getAllSchemas function', () => {
     it('returns all schemas', () => {
       const schemas = getAllSchemas();
-      expect(schemas).toHaveLength(9);
+      expect(schemas).toHaveLength(8);
       expect(schemas).toContain(certificationSchema);
       expect(schemas).toContain(commonSchema);
       expect(schemas).toContain(controllerWitnessSchema);
-      expect(schemas).toContain(endorsementSchema);
       expect(schemas).toContain(keyBindingSchema);
       expect(schemas).toContain(linkedIdentifierSchema);
       expect(schemas).toContain(securityAssessmentSchema);

--- a/tests/lib/controller-witness-client.test.ts
+++ b/tests/lib/controller-witness-client.test.ts
@@ -1,20 +1,19 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import {
-  callControllerWitness,
-} from '@/lib/controller-witness-client'
+import { callControllerWitness } from '@/lib/controller-witness-client'
 import * as loggerModule from '@/lib/logger'
 
-// Mock the logger
 vi.mock('@/lib/logger', () => ({
   default: { log: vi.fn(), error: vi.fn() },
 }))
 
+vi.mock('@/lib/service-urls', () => ({
+  getBackendOrigin: () => 'https://backend.test',
+}))
+
+const WITNESS_URL = 'https://backend.test/api/private/controller-witness'
+
 describe('controller-witness-client', () => {
   const baseParams = {
-    attestationUid: '0xabc123',
-    chainId: 66238,
-    easContract: '0xeascontract',
-    schemaUid: '0xschemauid',
     subject: 'did:web:example.com',
     controller: 'did:pkh:eip155:1:0xwallet',
   }
@@ -28,303 +27,104 @@ describe('controller-witness-client', () => {
     vi.restoreAllMocks()
   })
 
-  it('tries dns-txt first and returns result on success', async () => {
-    const successResponse = {
-      uid: '0xwitness',
-      txHash: '0xtx',
-      observedAt: 1700000000,
-    }
-
+  function mockFetchResponse(body: unknown, status = 200) {
     ;(global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
-      new Response(JSON.stringify(successResponse), {
-        status: 200,
+      new Response(JSON.stringify(body), {
+        status,
         headers: { 'Content-Type': 'application/json' },
       })
     )
+  }
 
-    const result = await callControllerWitness(baseParams)
-
-    expect(result).toEqual(successResponse)
-    expect(global.fetch).toHaveBeenCalledTimes(1)
-
-    // Verify dns-txt was the method used
-    const body = JSON.parse(
-      (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][1].body
-    )
-    expect(body.method).toBe('dns-txt')
-  })
-
-  it('falls back to did-json when dns-txt fails (non-ok response)', async () => {
-    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
-
-    // dns-txt returns 404
-    fetchMock.mockResolvedValueOnce(
-      new Response(JSON.stringify({ code: 'EVIDENCE_NOT_FOUND' }), {
-        status: 404,
-        headers: { 'Content-Type': 'application/json' },
-      })
-    )
-
-    // did-json returns success
-    const successResponse = { uid: '0xwitness2', txHash: '0xtx2' }
-    fetchMock.mockResolvedValueOnce(
-      new Response(JSON.stringify(successResponse), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      })
-    )
-
-    const result = await callControllerWitness(baseParams)
-
-    expect(result).toEqual(successResponse)
-    expect(fetchMock).toHaveBeenCalledTimes(2)
-
-    // Verify methods
-    const call1Body = JSON.parse(fetchMock.mock.calls[0][1].body)
-    const call2Body = JSON.parse(fetchMock.mock.calls[1][1].body)
-    expect(call1Body.method).toBe('dns-txt')
-    expect(call2Body.method).toBe('did-json')
-  })
-
-  it('falls back to did-json when dns-txt throws an exception', async () => {
-    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
-
-    // dns-txt throws
-    fetchMock.mockRejectedValueOnce(new Error('Network error'))
-
-    // did-json returns success
-    const successResponse = { uid: '0xwitness3' }
-    fetchMock.mockResolvedValueOnce(
-      new Response(JSON.stringify(successResponse), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      })
-    )
-
-    const result = await callControllerWitness(baseParams)
-
-    expect(result).toEqual(successResponse)
-    expect(fetchMock).toHaveBeenCalledTimes(2)
-  })
-
-  it('returns undefined when all methods fail', async () => {
-    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
-
-    // Both methods return errors
-    fetchMock.mockResolvedValueOnce(
-      new Response(JSON.stringify({ code: 'EVIDENCE_NOT_FOUND' }), {
-        status: 404,
-        headers: { 'Content-Type': 'application/json' },
-      })
-    )
-    fetchMock.mockResolvedValueOnce(
-      new Response(JSON.stringify({ code: 'EVIDENCE_NOT_FOUND' }), {
-        status: 404,
-        headers: { 'Content-Type': 'application/json' },
-      })
-    )
-
-    const result = await callControllerWitness(baseParams)
-
-    expect(result).toBeUndefined()
-    expect(fetchMock).toHaveBeenCalledTimes(2)
-  })
-
-  it('returns undefined when all methods throw exceptions', async () => {
-    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
-
-    fetchMock.mockRejectedValueOnce(new Error('dns-txt error'))
-    fetchMock.mockRejectedValueOnce(new Error('did-json error'))
-
-    const result = await callControllerWitness(baseParams)
-
-    expect(result).toBeUndefined()
-    expect(fetchMock).toHaveBeenCalledTimes(2)
-  })
-
-  it('sends correct request payload including all fields', async () => {
-    ;(global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
-      new Response(JSON.stringify({ uid: '0x1' }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      })
-    )
+  it('posts to the private controller-witness endpoint with the mapped payload', async () => {
+    mockFetchResponse({ success: true, uid: '0x1', method: 'dns-txt', txHash: '0xtx' })
 
     await callControllerWitness(baseParams)
 
+    expect(global.fetch).toHaveBeenCalledTimes(1)
     const [url, options] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0]
-    const body = JSON.parse(options.body)
+    expect(url).toBe(WITNESS_URL)
+    expect(options.method).toBe('POST')
+    expect(options.credentials).toBe('include')
+    expect(options.headers['Content-Type']).toBe('application/json')
+    expect(JSON.parse(options.body)).toEqual({
+      subjectDid: baseParams.subject,
+      controllerDid: baseParams.controller,
+    })
+  })
 
-    expect(body).toEqual({
-      ...baseParams,
+  it('returns the parsed witness result on success', async () => {
+    const successResponse = {
+      success: true,
+      uid: '0xwitness',
+      txHash: '0xtx',
+      blockNumber: 123,
+      observedAt: 1700000000,
+      method: 'dns-txt',
+    }
+    mockFetchResponse(successResponse)
+
+    const result = await callControllerWitness(baseParams)
+
+    expect(result).toEqual(successResponse)
+  })
+
+  it('returns undefined and logs an API error on a non-ok response', async () => {
+    mockFetchResponse({ error: 'EVIDENCE_NOT_FOUND' }, 404)
+
+    const result = await callControllerWitness(baseParams)
+
+    expect(result).toBeUndefined()
+    expect(loggerModule.default.log).toHaveBeenCalledWith(
+      '[controller-witness] API error:',
+      404,
+      expect.objectContaining({ error: 'EVIDENCE_NOT_FOUND' })
+    )
+  })
+
+  it('returns undefined and logs an error when fetch throws', async () => {
+    ;(global.fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('Network error'))
+
+    const result = await callControllerWitness(baseParams)
+
+    expect(result).toBeUndefined()
+    expect(loggerModule.default.log).toHaveBeenCalledWith(
+      '[controller-witness] Error:',
+      expect.any(Error)
+    )
+  })
+
+  it('logs the start of the witness call with subject and controller', async () => {
+    mockFetchResponse({ success: true, uid: '0x1' })
+
+    await callControllerWitness(baseParams)
+
+    expect(loggerModule.default.log).toHaveBeenCalledWith(
+      '[controller-witness] Starting witness call:',
+      expect.objectContaining({
+        subject: baseParams.subject,
+        controller: baseParams.controller,
+      })
+    )
+  })
+
+  it('logs success with the witness details', async () => {
+    mockFetchResponse({
+      success: true,
+      uid: '0xwitness',
+      txHash: '0xtx',
       method: 'dns-txt',
     })
-    expect(options.headers['Content-Type']).toBe('application/json')
-    expect(options.method).toBe('POST')
-  })
-
-  it('uses NEXT_PUBLIC_CONTROLLER_WITNESS_URL env when set', async () => {
-    // The URL is read at module init time, so we need to reset modules
-    vi.resetModules()
-
-    // Set the env before importing
-    process.env.NEXT_PUBLIC_CONTROLLER_WITNESS_URL = 'https://custom-gateway.com/v1/cw'
-
-    const mod = await import('@/lib/controller-witness-client')
-
-    ;(global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
-      new Response(JSON.stringify({ uid: '0x1' }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      })
-    )
-
-    await mod.callControllerWitness(baseParams)
-
-    expect(global.fetch).toHaveBeenCalledWith(
-      'https://custom-gateway.com/v1/cw',
-      expect.any(Object)
-    )
-
-    // Cleanup
-    delete process.env.NEXT_PUBLIC_CONTROLLER_WITNESS_URL
-  })
-
-  it('logs the start of witness call', async () => {
-    ;(global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
-      new Response(JSON.stringify({ uid: '0x1' }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      })
-    )
-
-    await callControllerWitness(baseParams)
-
-    expect(loggerModule.default.log).toHaveBeenCalledWith(
-      '[controller-witness] Starting witness call:',
-      expect.objectContaining({
-        attestationUid: baseParams.attestationUid,
-        subject: baseParams.subject,
-        controller: baseParams.controller,
-      })
-    )
-  })
-
-  it('logs success with witness details', async () => {
-    const successResponse = {
-      uid: '0xwitness',
-      txHash: '0xtx',
-      observedAt: 1700000000,
-      existing: false,
-    }
-
-    ;(global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
-      new Response(JSON.stringify(successResponse), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      })
-    )
 
     await callControllerWitness(baseParams)
 
     expect(loggerModule.default.log).toHaveBeenCalledWith(
       '[controller-witness] Witness attestation created:',
       expect.objectContaining({
-        method: 'dns-txt',
         uid: '0xwitness',
+        method: 'dns-txt',
         txHash: '0xtx',
       })
-    )
-  })
-
-  it('logs all-methods-failed summary when API returns non-ok for all methods', async () => {
-    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
-
-    // dns-txt returns 404 with specific error code
-    fetchMock.mockResolvedValueOnce(
-      new Response(JSON.stringify({ code: 'EVIDENCE_NOT_FOUND' }), {
-        status: 404,
-        headers: { 'Content-Type': 'application/json' },
-      })
-    )
-
-    // did-json returns 500 with server error code
-    fetchMock.mockResolvedValueOnce(
-      new Response(JSON.stringify({ code: 'INTERNAL_ERROR' }), {
-        status: 500,
-        headers: { 'Content-Type': 'application/json' },
-      })
-    )
-
-    await callControllerWitness(baseParams)
-
-    // Current implementation logs start + all-methods-failed summary.
-    expect(loggerModule.default.log).toHaveBeenCalledWith(
-      '[controller-witness] Starting witness call:',
-      expect.objectContaining({
-        attestationUid: baseParams.attestationUid,
-        subject: baseParams.subject,
-        controller: baseParams.controller,
-      })
-    )
-    expect(loggerModule.default.log).toHaveBeenCalledWith(
-      '[controller-witness] All methods failed (non-blocking)'
-    )
-  })
-
-  it('logs fallback success when first method throws and second succeeds', async () => {
-    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
-
-    // dns-txt throws a network error
-    fetchMock.mockRejectedValueOnce(new Error('ECONNREFUSED'))
-
-    // did-json succeeds, so client should log final witness creation.
-    fetchMock.mockResolvedValueOnce(
-      new Response(JSON.stringify({ uid: '0xrecovered' }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      })
-    )
-
-    await callControllerWitness(baseParams)
-
-    expect(loggerModule.default.log).toHaveBeenCalledWith(
-      '[controller-witness] Starting witness call:',
-      expect.objectContaining({
-        attestationUid: baseParams.attestationUid,
-        subject: baseParams.subject,
-        controller: baseParams.controller,
-      })
-    )
-    expect(loggerModule.default.log).toHaveBeenCalledWith(
-      '[controller-witness] Witness attestation created:',
-      expect.objectContaining({
-        method: 'did-json',
-        uid: '0xrecovered',
-      })
-    )
-  })
-
-  it('logs when all methods fail', async () => {
-    const fetchMock = global.fetch as ReturnType<typeof vi.fn>
-
-    fetchMock.mockResolvedValueOnce(
-      new Response(JSON.stringify({ code: 'err' }), {
-        status: 500,
-        headers: { 'Content-Type': 'application/json' },
-      })
-    )
-    fetchMock.mockResolvedValueOnce(
-      new Response(JSON.stringify({ code: 'err' }), {
-        status: 500,
-        headers: { 'Content-Type': 'application/json' },
-      })
-    )
-
-    await callControllerWitness(baseParams)
-
-    expect(loggerModule.default.log).toHaveBeenCalledWith(
-      '[controller-witness] All methods failed (non-blocking)'
     )
   })
 })

--- a/tests/lib/omatrust-backend.test.ts
+++ b/tests/lib/omatrust-backend.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  BackendApiError,
+  isBackendNetworkError,
+  getBackendErrorMessage,
+  shouldRouteBackendErrorToAccount,
+  buildWalletDid,
+  deriveDidWebFromInput,
+  deriveSubjectUrlHint,
+  getSessionMe,
+  logoutSession,
+  getControllerConfirmation,
+  getRelayEasNonce,
+  postRelayEasDelegatedAttest,
+} from '@/lib/omatrust-backend';
+
+vi.mock('@/lib/service-urls', () => ({
+  getBackendOrigin: () => 'https://backend.test',
+}));
+
+describe('omatrust-backend pure helpers', () => {
+  describe('BackendApiError', () => {
+    it('captures status, code, and details', () => {
+      const err = new BackendApiError('boom', 409, 'CONFLICT', 'already exists');
+      expect(err).toBeInstanceOf(Error);
+      expect(err.name).toBe('BackendApiError');
+      expect(err.message).toBe('boom');
+      expect(err.status).toBe(409);
+      expect(err.code).toBe('CONFLICT');
+      expect(err.details).toBe('already exists');
+    });
+  });
+
+  describe('isBackendNetworkError', () => {
+    it('is true only for the BACKEND_UNREACHABLE code', () => {
+      expect(isBackendNetworkError(new BackendApiError('x', 0, 'BACKEND_UNREACHABLE'))).toBe(true);
+      expect(isBackendNetworkError(new BackendApiError('x', 500, 'INTERNAL'))).toBe(false);
+      expect(isBackendNetworkError(new Error('x'))).toBe(false);
+    });
+  });
+
+  describe('getBackendErrorMessage', () => {
+    it('maps known backend error codes to friendly copy', () => {
+      expect(getBackendErrorMessage(new BackendApiError('x', 402, 'SPONSORED_WRITE_LIMIT_EXCEEDED')))
+        .toMatch(/used all sponsored writes/i);
+      expect(getBackendErrorMessage(new BackendApiError('x', 402, 'SUBSCRIPTION_INACTIVE')))
+        .toMatch(/subscription is not active/i);
+      expect(getBackendErrorMessage(new BackendApiError('x', 400, 'SCHEMA_NOT_ELIGIBLE')))
+        .toMatch(/not available for sponsored publishing/i);
+      expect(getBackendErrorMessage(new BackendApiError('x', 400, 'ATTESTER_MISMATCH')))
+        .toMatch(/does not match the signed-in account/i);
+    });
+
+    it('falls back to details then message for unknown codes', () => {
+      expect(getBackendErrorMessage(new BackendApiError('the message', 500, 'WHATEVER', 'the details')))
+        .toBe('the details');
+      expect(getBackendErrorMessage(new BackendApiError('the message', 500, 'WHATEVER')))
+        .toBe('the message');
+    });
+
+    it('handles plain errors and unknown values', () => {
+      expect(getBackendErrorMessage(new Error('plain'))).toBe('plain');
+      expect(getBackendErrorMessage('not-an-error')).toMatch(/something went wrong/i);
+    });
+  });
+
+  describe('shouldRouteBackendErrorToAccount', () => {
+    it('is true for billing/subscription codes only', () => {
+      expect(shouldRouteBackendErrorToAccount(new BackendApiError('x', 402, 'SPONSORED_WRITE_LIMIT_EXCEEDED'))).toBe(true);
+      expect(shouldRouteBackendErrorToAccount(new BackendApiError('x', 402, 'SUBSCRIPTION_INACTIVE'))).toBe(true);
+      expect(shouldRouteBackendErrorToAccount(new BackendApiError('x', 400, 'ATTESTER_MISMATCH'))).toBe(false);
+      expect(shouldRouteBackendErrorToAccount(new Error('x'))).toBe(false);
+    });
+  });
+
+  describe('buildWalletDid', () => {
+    it('builds a did:pkh from address and chainId', () => {
+      expect(buildWalletDid('0xabc', 1)).toBe('did:pkh:eip155:1:0xabc');
+      expect(buildWalletDid('0xdef', 66238)).toBe('did:pkh:eip155:66238:0xdef');
+    });
+  });
+
+  describe('deriveDidWebFromInput', () => {
+    it('returns null for empty input', () => {
+      expect(deriveDidWebFromInput('')).toBeNull();
+      expect(deriveDidWebFromInput('   ')).toBeNull();
+    });
+
+    it('passes through an existing did:web', () => {
+      expect(deriveDidWebFromInput('did:web:example.com')).toBe('did:web:example.com');
+    });
+
+    it('derives did:web from a bare domain', () => {
+      expect(deriveDidWebFromInput('Example.com')).toBe('did:web:example.com');
+    });
+
+    it('derives did:web from a full URL with path', () => {
+      expect(deriveDidWebFromInput('https://Example.com/some/path')).toBe('did:web:example.com');
+    });
+  });
+
+  describe('deriveSubjectUrlHint', () => {
+    it('returns empty string for nullish/blank input', () => {
+      expect(deriveSubjectUrlHint(null)).toBe('');
+      expect(deriveSubjectUrlHint(undefined)).toBe('');
+      expect(deriveSubjectUrlHint('   ')).toBe('');
+    });
+
+    it('strips the did:web: prefix', () => {
+      expect(deriveSubjectUrlHint('did:web:example.com')).toBe('example.com');
+    });
+
+    it('returns the trimmed value for non-did:web input', () => {
+      expect(deriveSubjectUrlHint('  example.com  ')).toBe('example.com');
+    });
+  });
+});
+
+describe('omatrust-backend fetch wrapper', () => {
+  beforeEach(() => {
+    global.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function okResponse(body: unknown) {
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  it('sends credentials and JSON headers, and returns the parsed body', async () => {
+    const me = { account: { id: 'a1', displayName: 'Jane' }, wallet: null };
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(okResponse(me));
+
+    const result = await getSessionMe();
+
+    expect(result).toEqual(me);
+    const [url, options] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toBe('https://backend.test/api/private/session/me');
+    expect(options.credentials).toBe('include');
+    expect(options.headers['Content-Type']).toBe('application/json');
+  });
+
+  it('issues a POST for logout', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(okResponse({ success: true }));
+
+    const result = await logoutSession();
+
+    expect(result).toEqual({ success: true });
+    const [url, options] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toBe('https://backend.test/api/private/session/logout');
+    expect(options.method).toBe('POST');
+  });
+
+  it('throws a BackendApiError with code/details on a non-ok response', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'Limit exceeded', code: 'SPONSORED_WRITE_LIMIT_EXCEEDED', details: 'used 100/100' }), {
+        status: 402,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    await expect(getSessionMe()).rejects.toMatchObject({
+      name: 'BackendApiError',
+      status: 402,
+      code: 'SPONSORED_WRITE_LIMIT_EXCEEDED',
+      details: 'used 100/100',
+      message: 'Limit exceeded',
+    });
+  });
+
+  it('throws a BackendApiError with a default message when the error body is not JSON', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response('not json', { status: 500 })
+    );
+
+    await expect(getSessionMe()).rejects.toMatchObject({
+      name: 'BackendApiError',
+      status: 500,
+      message: 'Backend request failed with 500',
+    });
+  });
+
+  it('wraps fetch failures as BACKEND_UNREACHABLE', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('ECONNREFUSED'));
+
+    await expect(getSessionMe()).rejects.toMatchObject({
+      name: 'BackendApiError',
+      status: 0,
+      code: 'BACKEND_UNREACHABLE',
+    });
+  });
+
+  it('builds the controller-confirm query string from params', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(okResponse({ warnings: [] }));
+
+    await getControllerConfirmation({ subjectDid: 'did:web:example.com', walletDid: 'did:pkh:eip155:1:0xabc' });
+
+    const [url] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toContain('/api/public/controller-confirm?');
+    expect(url).toContain('subjectDid=did%3Aweb%3Aexample.com');
+    expect(url).toContain('walletDid=did%3Apkh%3Aeip155%3A1%3A0xabc');
+  });
+
+  it('omits walletDid from the query when not provided', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(okResponse({ warnings: [] }));
+
+    await getControllerConfirmation({ subjectDid: 'did:web:example.com' });
+
+    const [url] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toContain('subjectDid=did%3Aweb%3Aexample.com');
+    expect(url).not.toContain('walletDid=');
+  });
+
+  it('encodes the attester in the relay nonce query', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(okResponse({ nonce: '1' }));
+
+    await getRelayEasNonce('0xABC');
+
+    const [url] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toBe('https://backend.test/api/private/relay/eas/nonce?attester=0xABC');
+  });
+
+  it('serializes bigint values in the delegated-attest body', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(okResponse({ success: true }));
+
+    await postRelayEasDelegatedAttest({
+      attester: '0xabc',
+      prepared: { nonce: 5n },
+      signature: '0xsig',
+    });
+
+    const [, options] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    const body = JSON.parse(options.body);
+    expect(body.prepared.nonce).toBe('5');
+  });
+});

--- a/tests/lib/service-urls.test.ts
+++ b/tests/lib/service-urls.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+describe('service-urls', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  async function importFresh() {
+    return await import('@/lib/service-urls');
+  }
+
+  describe('buildServiceUrl', () => {
+    it('returns an http(s) URL unchanged except for trailing slashes', async () => {
+      const { buildServiceUrl } = await importFresh();
+      expect(buildServiceUrl('https://example.com/')).toBe('https://example.com');
+      expect(buildServiceUrl('http://example.com///')).toBe('http://example.com');
+    });
+
+    it('uses http:// for localhost and port-based local domains', async () => {
+      const { buildServiceUrl } = await importFresh();
+      expect(buildServiceUrl('localhost:3001')).toBe('http://localhost:3001');
+      expect(buildServiceUrl('127.0.0.1:8080')).toBe('http://127.0.0.1:8080');
+    });
+
+    it('applies no prefix for omachain-mainnet', async () => {
+      process.env.NEXT_PUBLIC_ACTIVE_CHAIN = 'omachain-mainnet';
+      const { buildServiceUrl } = await importFresh();
+      expect(buildServiceUrl('backend.omatrust.org')).toBe('https://backend.omatrust.org');
+    });
+
+    it('applies the preview. prefix for omachain-testnet', async () => {
+      process.env.NEXT_PUBLIC_ACTIVE_CHAIN = 'omachain-testnet';
+      const { buildServiceUrl } = await importFresh();
+      expect(buildServiceUrl('backend.omatrust.org')).toBe('https://preview.backend.omatrust.org');
+    });
+
+    it('applies the dev. prefix for omachain-devnet', async () => {
+      process.env.NEXT_PUBLIC_ACTIVE_CHAIN = 'omachain-devnet';
+      const { buildServiceUrl } = await importFresh();
+      expect(buildServiceUrl('backend.omatrust.org')).toBe('https://dev.backend.omatrust.org');
+    });
+
+    it('defaults to the preview. prefix for unknown chains', async () => {
+      process.env.NEXT_PUBLIC_ACTIVE_CHAIN = 'some-other-chain';
+      const { buildServiceUrl } = await importFresh();
+      expect(buildServiceUrl('backend.omatrust.org')).toBe('https://preview.backend.omatrust.org');
+    });
+
+    it('defaults to omachain-testnet (preview.) when no active chain is set', async () => {
+      delete process.env.NEXT_PUBLIC_ACTIVE_CHAIN;
+      const { buildServiceUrl } = await importFresh();
+      expect(buildServiceUrl('backend.omatrust.org')).toBe('https://preview.backend.omatrust.org');
+    });
+  });
+
+  describe('getBackendOrigin', () => {
+    it('builds the backend origin from the active chain + default domain', async () => {
+      process.env.NEXT_PUBLIC_ACTIVE_CHAIN = 'omachain-mainnet';
+      delete process.env.NEXT_PUBLIC_OMATRUST_BACKEND_DOMAIN;
+      const { getBackendOrigin } = await importFresh();
+      expect(getBackendOrigin()).toBe('https://backend.omatrust.org');
+    });
+
+    it('honors a custom backend domain override', async () => {
+      process.env.NEXT_PUBLIC_ACTIVE_CHAIN = 'omachain-testnet';
+      process.env.NEXT_PUBLIC_OMATRUST_BACKEND_DOMAIN = 'api.example.com';
+      const { getBackendOrigin } = await importFresh();
+      expect(getBackendOrigin()).toBe('https://preview.api.example.com');
+    });
+
+    it('treats a localhost backend domain as a local override', async () => {
+      process.env.NEXT_PUBLIC_OMATRUST_BACKEND_DOMAIN = 'localhost:3001';
+      const { getBackendOrigin } = await importFresh();
+      expect(getBackendOrigin()).toBe('http://localhost:3001');
+    });
+  });
+});

--- a/tests/lib/service.test.ts
+++ b/tests/lib/service.test.ts
@@ -21,6 +21,12 @@ vi.mock('thirdweb/react', () => ({
   useActiveWalletChain: vi.fn(),
 }));
 
+// The EAS client now reads the backend session; provide a benign default so the
+// hook can mount outside of a BackendSessionProvider.
+vi.mock('@/components/backend-session-provider', () => ({
+  useBackendSession: () => ({ session: null }),
+}));
+
 // Minimal valid AttestationData for tests
 const validAttestationData = { schemaId: 'schema', recipient: 'did:web:example.com', data: {} };
 function mockWallet(overrides = {}): ReturnType<typeof walletModule.useWallet> {
@@ -266,7 +272,9 @@ describe('controller witness integration in useAttestation', () => {
     vi.restoreAllMocks();
   });
 
-  it('fires controller witness call when schema has witness config and attestation succeeds', async () => {
+  it('does not fire a controller witness call from useAttestation even for witness-configured schemas', async () => {
+    // The controller-witness flow was moved out of useAttestation; submitting an
+    // attestation should no longer trigger callControllerWitness directly.
     const fakeResult = { transactionHash: '0xabc', attestationId: '0xattest123' };
     const easCreateAttestation = vi.fn().mockResolvedValue(fakeResult);
 
@@ -281,7 +289,6 @@ describe('controller witness integration in useAttestation', () => {
     );
     vi.spyOn(attestationServices, 'getContractAddress').mockReturnValue('0xeascontract');
 
-    // Mock getSchema to return a schema with witness config
     const schemasModule = await import('@/config/schemas');
     vi.spyOn(schemasModule, 'getSchema').mockReturnValue({
       id: 'key-binding',
@@ -290,11 +297,10 @@ describe('controller witness integration in useAttestation', () => {
       fields: [],
       witness: { subjectField: 'subject', controllerField: 'keyId' },
       deployedUIDs: { 66238: '0xschemauid' },
-    });
+    } as any);
 
-    // Mock callControllerWitness
     const cwModule = await import('@/lib/controller-witness-client');
-    vi.spyOn(cwModule, 'callControllerWitness').mockResolvedValue({ uid: '0xwitness', txHash: '0xwittx' });
+    vi.spyOn(cwModule, 'callControllerWitness').mockResolvedValue(undefined);
 
     const attestationData = {
       schemaId: 'key-binding',
@@ -316,17 +322,10 @@ describe('controller witness integration in useAttestation', () => {
     expect(easCreateAttestation).toHaveBeenCalledWith(attestationData);
     expect(result!.result.current.lastResult).toEqual(fakeResult);
 
-    // Give time for the non-blocking witness call
+    // Give time for any (now-removed) non-blocking call to have fired.
     await new Promise(resolve => setTimeout(resolve, 50));
 
-    expect(cwModule.callControllerWitness).toHaveBeenCalledWith({
-      attestationUid: '0xattest123',
-      chainId: 66238,
-      easContract: '0xeascontract',
-      schemaUid: '0xschemauid',
-      subject: 'did:web:example.com',
-      controller: 'did:pkh:eip155:1:0xabc',
-    });
+    expect(cwModule.callControllerWitness).not.toHaveBeenCalled();
   });
 
   it('does not fire controller witness when schema has no witness config', async () => {
@@ -573,14 +572,7 @@ describe('controller witness integration in useAttestation', () => {
     expect(cwModule.callControllerWitness).not.toHaveBeenCalled();
   });
 
-  it('does not affect attestation result when callControllerWitness rejects', async () => {
-    // The source code uses .then() without .catch() on the fire-and-forget witness call.
-    // This causes an unhandled promise rejection when the mock rejects. We capture it
-    // to prevent Vitest from reporting it as a test failure.
-    const rejections: Error[] = [];
-    const handler = (reason: unknown) => { rejections.push(reason as Error); };
-    process.on('unhandledRejection', handler);
-
+  it('returns the attestation result and leaves the witness client untouched', async () => {
     const fakeResult = { transactionHash: '0xabc', attestationId: '0xattest_reject' };
     const easCreateAttestation = vi.fn().mockResolvedValue(fakeResult);
 
@@ -603,11 +595,10 @@ describe('controller witness integration in useAttestation', () => {
       fields: [],
       witness: { subjectField: 'subject', controllerField: 'keyId' },
       deployedUIDs: { 66238: '0xschemauid' },
-    });
+    } as any);
 
-    // Mock callControllerWitness to REJECT
     const cwModule = await import('@/lib/controller-witness-client');
-    vi.spyOn(cwModule, 'callControllerWitness').mockRejectedValue(new Error('witness API down'));
+    const witnessSpy = vi.spyOn(cwModule, 'callControllerWitness').mockResolvedValue(undefined);
 
     const attestationData = {
       schemaId: 'key-binding',
@@ -626,15 +617,10 @@ describe('controller witness integration in useAttestation', () => {
       await result!.result.current.submitAttestation(attestationData, 66238);
     });
 
-    // The attestation itself should still succeed despite witness rejection
     expect(result!.result.current.lastResult).toEqual(fakeResult);
     expect(result!.result.current.lastError).toBeNull();
 
-    // Give time for the fire-and-forget promise to settle
     await new Promise(resolve => setTimeout(resolve, 50));
-    expect(cwModule.callControllerWitness).toHaveBeenCalled();
-
-    // Clean up rejection handler
-    process.removeListener('unhandledRejection', handler);
+    expect(witnessSpy).not.toHaveBeenCalled();
   });
 }); 

--- a/tests/lib/wallet-cleanup.test.ts
+++ b/tests/lib/wallet-cleanup.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { clearWalletBrowserState } from '@/lib/wallet-cleanup';
+
+describe('clearWalletBrowserState', () => {
+  let deleteDatabase: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    localStorage.clear();
+    deleteDatabase = vi.fn();
+    // jsdom does not implement indexedDB; provide a stub.
+    vi.stubGlobal('indexedDB', { deleteDatabase });
+  });
+
+  it('deletes the WalletConnect v2 IndexedDB database', () => {
+    clearWalletBrowserState();
+    expect(deleteDatabase).toHaveBeenCalledWith('WALLET_CONNECT_V2_INDEXED_DB');
+  });
+
+  it('removes thirdweb: and wc@2: localStorage keys but keeps others', () => {
+    localStorage.setItem('thirdweb:active-wallet', '1');
+    localStorage.setItem('wc@2:core:session', '1');
+    localStorage.setItem('unrelated-key', 'keep');
+
+    clearWalletBrowserState();
+
+    expect(localStorage.getItem('thirdweb:active-wallet')).toBeNull();
+    expect(localStorage.getItem('wc@2:core:session')).toBeNull();
+    expect(localStorage.getItem('unrelated-key')).toBe('keep');
+  });
+
+  it('swallows IndexedDB deletion errors and still cleans localStorage', () => {
+    deleteDatabase.mockImplementation(() => {
+      throw new Error('blocked by open connection');
+    });
+    localStorage.setItem('thirdweb:x', '1');
+
+    expect(() => clearWalletBrowserState()).not.toThrow();
+    expect(localStorage.getItem('thirdweb:x')).toBeNull();
+  });
+});

--- a/tests/mocks/omatrust-widgets.ts
+++ b/tests/mocks/omatrust-widgets.ts
@@ -1,0 +1,19 @@
+/**
+ * Default mock for `@oma3/omatrust/widgets` (see vitest.config.ts resolve.alias).
+ * Component tests that need spies should use vi.mock to replace `createSigningBridge`.
+ */
+export type SigningBridgeOptions = {
+  iframeId: string
+  devOriginOverride?: string
+  signTypedData: (
+    domain: Record<string, unknown>,
+    types: Record<string, unknown>,
+    message: Record<string, unknown>
+  ) => Promise<string>
+}
+
+export async function createSigningBridge(_options: SigningBridgeOptions) {
+  return {
+    destroy: () => {},
+  }
+}

--- a/tests/scripts/update-schemas.test.js
+++ b/tests/scripts/update-schemas.test.js
@@ -69,7 +69,7 @@ describe('update-schemas script', () => {
       await expect(transformToUISchema(badSchema, 'bad')).rejects.toThrow(/missing required 'title'/i)
     })
 
-    it('extracts x-oma3-witness configuration when present', async () => {
+    it('does not include witness configuration on the result (witness support removed)', async () => {
       const schema = {
         title: 'Key Binding',
         description: 'Bind a cryptographic key to a DID',
@@ -81,19 +81,6 @@ describe('update-schemas script', () => {
         required: ['subject', 'keyId'],
       }
       const result = await transformToUISchema(schema, 'key-binding')
-      expect(result.witness).toEqual({ subjectField: 'subject', controllerField: 'keyId' })
-    })
-
-    it('returns undefined witness when x-oma3-witness is not present', async () => {
-      const schema = {
-        title: 'Endorsement',
-        description: 'A simple endorsement',
-        properties: {
-          subject: { type: 'string', title: 'Subject' },
-        },
-        required: ['subject'],
-      }
-      const result = await transformToUISchema(schema, 'endorsement')
       expect(result.witness).toBeUndefined()
     })
 
@@ -230,9 +217,9 @@ describe('update-schemas script', () => {
       expect(result[0].default).toBe(10)
     })
 
-    it('handles x-oma3-default auto-default marker', async () => {
+    it('handles x-oma3-auto-default marker as autoDefault', async () => {
       const properties = {
-        timestamp: { type: 'string', title: 'Timestamp', 'x-oma3-default': 'current-timestamp' }
+        timestamp: { type: 'string', title: 'Timestamp', 'x-oma3-auto-default': 'current-timestamp' }
       }
       const result = await transformFields(properties, [], 'test')
       expect(result[0].autoDefault).toBe('current-timestamp')
@@ -286,12 +273,12 @@ describe('update-schemas script', () => {
       expect(result[0].placeholder).toBe('0')
     })
 
-    it('generates default placeholder for other fields', async () => {
+    it('generates default placeholder for other fields based on title', async () => {
       const properties = {
         userName: { type: 'string', title: 'User Name' }
       }
       const result = await transformFields(properties, [], 'test')
-      expect(result[0].placeholder).toBe('Enter username')
+      expect(result[0].placeholder).toBe('Enter user name')
     })
 
     it('handles object fields with expanded render mode (default)', async () => {
@@ -474,7 +461,7 @@ describe('update-schemas script', () => {
         timestamp: {
           type: 'integer',
           title: 'Timestamp',
-          'x-oma3-default': 'current-timestamp',
+          'x-oma3-auto-default': 'current-timestamp',
           'x-oma3-subtype': 'timestamp'
         }
       }
@@ -503,14 +490,14 @@ describe('update-schemas script', () => {
       const properties = {
         did: { type: 'string', title: 'DID' },
         subjectDID: { type: 'string', title: 'Subject DID' },
-        userDid: { type: 'string', title: 'User DID' }
+        plainName: { type: 'string', title: 'Plain Name' }
       }
       const result = await transformFields(properties, [], 'test')
       // The code checks for 'did' or 'DID' in the field name
       expect(result[0].placeholder).toBe('did:example:123...')
       expect(result[1].placeholder).toBe('did:example:123...')
-      // 'userDid' contains 'did' (lowercase) so it matches
-      expect(result[2].placeholder).toBe('Enter userdid')
+      // 'plainName' contains neither 'did' nor 'DID', falls through to title-based default
+      expect(result[2].placeholder).toBe('Enter plain name')
     })
 
     it('handles enum with integer options', async () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -59,6 +59,10 @@ export default defineConfig({
         __dirname,
         './node_modules/@oma3/omatrust/dist/reputation/index.cjs'
       ),
+      '@oma3/omatrust/widgets': path.resolve(
+        __dirname,
+        './tests/mocks/omatrust-widgets.ts'
+      ),
     },
   },
 }) 

--- a/vitest.setup.js
+++ b/vitest.setup.js
@@ -5,6 +5,8 @@ import { vi } from 'vitest';
 
 // Mock scrollIntoView which doesn't exist in jsdom
 Element.prototype.scrollIntoView = vi.fn();
+// Mock scrollTo which doesn't exist in jsdom
+window.scrollTo = vi.fn();
 
 // Silence act() warnings in test output
 const originalError = console.error;


### PR DESCRIPTION
## Risk Level

**Risk:** low

## Summary

Brings the test suite back to green after the staging portal redesign and adds coverage for the areas most likely to regress again.

**Fixes (aligned with staging behavior):**
- App pages: landing page, dashboard (session gating, table/revoke flow), attest → publish redirects, sitemap URLs/routes, layout fonts
- Components: semantic Tailwind classes, `TimestampInput` toggle behavior, `FieldRenderer`/`SubjectIdInput`, attestation card full addresses + star rating
- Library: rewritten `controller-witness-client` tests (single POST API), removed obsolete witness integration from `useAttestation`, `client.test.ts` timeout fix
- Dashboard: schema-accurate backend mocks (`ControllerConfirmResponse.warnings`, trust anchors) and `ServiceTrustWorkspace` smoke tests

**New coverage:**
- Publish form page, auth/session (`backend-session-provider`, `auth-entry-dialog`, `subject-confirmation-dialog`)
- Backend helpers (`omatrust-backend`, `service-urls`, `wallet-cleanup`)
- Home/dashboard UI (`WorkflowCards`, `LatestTrustProfiles`, `PublishButton`, `star-rating`, `did-jwk-input`, `ProofArrayInput`)

**Test infra:**
- `@oma3/omatrust/widgets` test mock alias
- jsdom polyfills in `vitest.setup.js`

## Testing Performed

- [x] `npm test` — **83 files, 963 tests passing** locally
- [x] Branch verified as **1 commit ahead of `staging`** only (no `main` changes)
- [ ] CI lint / typecheck / build / test (pending on GitHub)

## CI Status

- [ ] All required checks pass