### PR TITLE
fix(test): stabilize UID parsing tests (fixes #58)

### DIFF
--- a/tests/lib/eas-routes.test.ts
+++ b/tests/lib/eas-routes.test.ts
@@ -629,13 +629,16 @@ describe('submitDelegatedAttestation', () => {
   });
 
   describe('UID parsing from event logs (Issue #32)', () => {
+    let uidParseSubmissionCounter = 0;
+
     function setupSuccessfulSubmission() {
       return async (logs: Array<{ topics: string[]; data: string }>) => {
         const { loadEasDelegatePrivateKey } = await import('@/lib/server/eas-delegate-key');
         (loadEasDelegatePrivateKey as any).mockReturnValue('0x' + 'f'.repeat(64));
 
         const { Wallet, Contract, keccak256 } = await import('ethers');
-        (keccak256 as any).mockReturnValue('0xuidparsetest_' + Date.now());
+        uidParseSubmissionCounter += 1;
+        (keccak256 as any).mockReturnValue(`0xuidparsetest_${uidParseSubmissionCounter}`);
         (Wallet as any).mockReturnValue({ address: '0xdelegateaddress' });
 
         const expectedTxHash = '0x' + 'e'.repeat(64);


### PR DESCRIPTION
## Summary
- Fixes flaky UID parsing tests (TC-4, TC-5, TC-6) caused by shared idempotency state in `eas-routes.ts` (#58)
- Replaces `Date.now()`-based `keccak256` mocks in `setupSuccessfulSubmission()` with an incrementing counter so each test gets a unique signature hash
- Test-only change; no production code modifications

## Test plan
- [x] `npm test -- tests/lib/eas-routes.test.ts` passes (30/30)
- [x] UID parsing cases TC-3 through TC-6 run without intermittent `DUPLICATE` errors