### PR TITLE
fix: update mainnet RPC to rpc.omachain.org

### DIFF
--- a/src/config/chains.ts
+++ b/src/config/chains.ts
@@ -43,7 +43,7 @@ export const omachainTestnet = {
 export const omachainMainnet = {
   id: 6623,
   chainId: 6623,
-  rpc: "https://rpc.chain.oma3.org/", // TODO: Update when mainnet is available
+  rpc: "https://rpc.omachain.org/",
   name: "OMAChain Mainnet",
   nativeCurrency: {
     name: "OMA",

--- a/tests/lib/eas-routes.test.ts
+++ b/tests/lib/eas-routes.test.ts
@@ -42,7 +42,7 @@ vi.mock('@/config/chains', () => ({
   omachainMainnet: {
     id: 6623,
     name: 'OMAChain Mainnet',
-    rpc: 'https://rpc.chain.oma3.org/',
+    rpc: 'https://rpc.omachain.org/',
   },
 }));
 

--- a/tests/lib/thirdweb-maintenance.test.ts
+++ b/tests/lib/thirdweb-maintenance.test.ts
@@ -167,7 +167,7 @@ vi.mock('@/config/chains', () => ({
   omachainMainnet: {
     id: 6623,
     name: 'OMAChain Mainnet',
-    rpc: 'https://rpc.chain.oma3.org/',
+    rpc: 'https://rpc.omachain.org/',
   },
 }));
 


### PR DESCRIPTION
## Risk Level

**Risk:** low

## Summary

Fixes the RPC URL for mainnet

## Testing Performed

npm run lint && npm run typecheck && npm test
manual localhost

## CI Status

- [x] All required checks pass

## Self-Merge

- [x] This is a self-merge
- **Reason for emergency self-merge:**
 Production is not working

- **Post-merge reviewer:** @OMA3Support 


### Labels

`self-merged` · `emergency` · `post-merge-review-needed` · `launch-blocker` · `low-risk` 
