### PR TITLE
fix: update mainnet explorer URL and exclude build dirs from eslint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,7 +12,7 @@ const compat = new FlatCompat({
 const config = [
   ...compat.extends("next/core-web-vitals"),
   {
-    ignores: ["temp/**"],
+    ignores: ["temp/**", ".next/**", "coverage/**"],
   },
 ];
 

--- a/src/config/chains.ts
+++ b/src/config/chains.ts
@@ -53,8 +53,8 @@ export const omachainMainnet = {
   blockExplorers: [
     {
       name: "OMAChain Explorer",
-      url: "https://explorer.chain.oma3.org",
-      apiUrl: "https://explorer.chain.oma3.org/api",
+      url: "https://explorer.omachain.org",
+      apiUrl: "https://explorer.omachain.org/api",
     },
   ],
   testnet: false,


### PR DESCRIPTION
## Risk Level

**Risk:** low

## Summary

The title explains it

## Testing Performed

Manual and automated. 

## CI Status

- [ ] All required checks pass

## Self-Merge

- [ ] This is a self-merge
- [ ] 
- **Reason for emergency self-merge:**

For some reason Vercel didn't pick up the last merge to main, so to test it again I'm adding in another fix to see if it deploys this time. 

- **Post-merge reviewer:** @OMA3Support 

---

### Labels

`self-merged` · `low-risk` 
