### PR TITLE
feat: implement verify page and replace Caip10Input with DidPkhInput

### DIFF
--- a/docs/features/verify/plan.md
+++ b/docs/features/verify/plan.md
@@ -1,0 +1,34 @@
+# Trust Verifier --- Test Cases
+
+**Status: Implemented**
+
+Use `spec.md` as the source of truth. This file tracks core scenarios for
+the `/verify` implementation.
+
+## Subject Verification
+
+- ✅ Subject only: verifies a supported subject DID and renders a trust profile.
+- ✅ Unknown subject: renders an empty trust profile without failing the page.
+- ✅ No attestations: renders the attestations empty state for the selected subject.
+- ✅ Proof verification: renders "Verified" badge when proofs pass; no badge when they don't (no red "Failed").
+- ✅ Category priority: attestations sorted by importance (security assessments first, user reviews last).
+- ✅ User review cap: maximum 20 user reviews displayed.
+- ✅ Trusted badge: security assessments and certifications from approved issuers show "Trusted" badge.
+
+## Controller Authorization
+
+- ✅ Subject plus controller: renders key authorization card with mechanisms and Basic/Intermediate/Advanced signals.
+- ✅ Controller authorization uses backend `getControllerConfirmation` (same as dashboard) plus attestation data.
+- ✅ Controller not found: card shows "Not authorized" with no mechanisms and all signals inactive.
+- ✅ DNS TXT evidence: mechanisms list includes "DNS TXT" when key is found in DNS.
+- ✅ Controller witnesses: intermediate signal active when controller-witness attestations exist for the key.
+- ✅ Key binding: advanced signal active when both controller witness and key binding exist.
+- ✅ Authorization card displayed first (before trust profile) when controller is provided.
+
+## Attestation Card Display
+
+- ✅ Controller witness cards show: Controller DID, Method, Observed date.
+- ✅ User review cards hide the verification/status section in the list (shown in detail modal only).
+- ✅ Status section uses "Not revoked" / "Not expired" / "Verified" / "Not verified" labels.
+- ✅ Failed checks use gray (secondary) badges, not red destructive badges.
+- ✅ Failure reasons use muted text color.

--- a/docs/features/verify/spec.md
+++ b/docs/features/verify/spec.md
@@ -1,0 +1,103 @@
+# Trust Verifier --- Specification
+
+**Status: Implemented**
+
+## Purpose
+
+The Trust Verifier provides a visual interface for inspecting a subject's trust
+profile, verifying attestations, and optionally determining whether a
+controller/signing key is authorized for that subject.
+
+## Scope
+
+### In Scope
+
+-   Dedicated `/verify` page.
+-   Subject verification with attestation list sorted by category priority.
+-   Optional controller/signing key authorization verification.
+-   Reuse existing UI components (attestation cards, badges, subject picker).
+-   "Verified" badge for attestations that pass proof verification.
+-   "Trusted" badge for security assessments and certifications from approved issuers in the trust anchors.
+-   Category-priority ordering (security assessments → certifications → controller witnesses → key bindings → linked identifiers → user reviews).
+-   User review cap (20 max in the verify results).
+
+### UI
+
+#### Inputs
+
+Required:
+- Subject — Subject Type picker (reuse existing SubjectIdInput)
+  - Web Domain / URL
+  - Blockchain Address
+  - JWK Key
+
+Optional:
+- Controller / Signing Key (reuse SubjectIdInput with pkh/jwk methods)
+
+#### Verify Button
+
+Runs verification and renders results.
+
+## Trust Profile
+
+Display:
+
+-   Subject DID
+-   Canonical DID
+-   Subject type badge
+-   Summary counts:
+    -   Reviews
+    -   Certifications
+    -   Security Assessments
+    -   Controller Witnesses
+    -   Key Bindings
+
+## Attestations
+
+Lists all attestations for the subject, sorted by category priority (most important trust signals first, user reviews last).
+
+Uses the shared `LatestAttestations` component with pre-fetched data.
+
+Each card displays:
+
+-   Schema icon and title
+-   Attester
+-   Service ID
+-   Date
+-   Active/Revoked status badge
+-   "Verified" badge (green, with CheckCircle2) when proof verification passes
+-   "Trusted" badge (amber, with CheckCircle2) when attester is an approved issuer for that schema
+-   Status section with check badges (Not revoked, Not expired, Verified) — hidden on list cards for user reviews, shown in detail modal
+-   Controller witness cards additionally show: Controller DID, Method, Observed date
+
+## Controller Authorization
+
+Shown only when the optional controller/signing key is supplied. Displayed as the **first section** in the results.
+
+Uses `getControllerConfirmation` from the OMATrust backend (same as the dashboard) combined with attestation data to derive authorization levels.
+
+Card displays:
+
+-   Service ID
+-   Key ID
+-   Mechanisms used (DNS TXT, DID document, Controller witness, Key binding)
+-   Basic / Intermediate / Advanced signal badges
+-   Authorized / Not authorized status badge
+
+## Implementation Notes
+
+-   Removed the frontend `/api/verify/controller-authorization` route. Controller authorization uses the backend's `controller-confirm` endpoint directly.
+-   Verification detail section uses "Status" heading (not "Verification"). Check names are user-friendly: "Not revoked", "Not expired", "Verified" / "Not verified".
+-   Failed verification checks use gray (secondary) badges, not red. Failure reasons use muted text, not destructive.
+-   Trust anchors are fetched alongside attestations to determine the "Trusted" badge.
+
+## Acceptance Criteria
+
+-   ✅ Verify page available at `/verify`
+-   ✅ Subject verification works without controller input
+-   ✅ Optional controller input enables authorization card (displayed first)
+-   ✅ Attestations display verification status with "Verified" and "Trusted" badges
+-   ✅ Attestations sorted by category priority
+-   ✅ User reviews capped at 20, verification detail hidden from list cards
+-   ✅ Existing UI components reused (LatestAttestations, AttestationCard, SubjectIdInput, Badge)
+-   ✅ No red "Failed" badges — absence of green indicates not verified

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -51,7 +51,7 @@ import { getContractAddress } from "@/config/attestation-services"
 import { getChainById } from "@/config/chains"
 import { callControllerWitness } from "@/lib/controller-witness-client"
 import { PublicKeyInput } from "@/components/public-key-input"
-import { Caip10Input } from "@/components/caip10-input"
+import { DidPkhInput } from "@/components/did-pkh-input"
 
 const activeThirdwebChain = getActiveThirdwebChain()
 
@@ -899,9 +899,9 @@ function AddSigningKeyDialog({
             </div>
 
             {keyMethod === "pkh" && !isEdit ? (
-              <Caip10Input
-                value={keyDid.startsWith("did:pkh:") ? keyDid.replace("did:pkh:", "") : ""}
-                onChange={(caip10) => setKeyDid(caip10 ? `did:pkh:${caip10}` : "")}
+              <DidPkhInput
+                value={keyDid}
+                onChange={(did) => setKeyDid(did ?? "")}
               />
             ) : null}
 

--- a/src/app/verify/page.tsx
+++ b/src/app/verify/page.tsx
@@ -1,0 +1,378 @@
+"use client"
+
+import { FormEvent, useMemo, useState } from "react"
+import { ShieldCheck, Search, XCircle, CheckCircle2 } from "lucide-react"
+import { isSameControllerId } from "@oma3/omatrust/identity"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { SubjectIdInput } from "@/components/SubjectIdInput"
+import { LatestAttestations } from "@/components/latest-attestations"
+import {
+  getVerifiedAttestationsForDIDWithMetadata,
+  sortByCategoryPriority,
+  type EnrichedAttestationResult,
+} from "@/lib/attestation-queries"
+import {
+  getControllerConfirmation,
+  getPublicTrustAnchors,
+  type ControllerConfirmResponse,
+} from "@/lib/omatrust-backend"
+
+/** Derived key authorization info for the simplified card. */
+type KeyAuthorizationInfo = {
+  subjectDid: string
+  controllerDid: string
+  sources: string[]
+  basic: boolean
+  intermediate: boolean
+  advanced: boolean
+}
+
+type VerifyResult = {
+  subjectDid: string
+  canonicalDid: string
+  attestations: EnrichedAttestationResult[]
+  keyAuthorization: KeyAuthorizationInfo | null
+  keyAuthorizationError: string | null
+  /** Approved issuer addresses (lowercased) → set of schema IDs they're approved for */
+  approvedIssuers: Map<string, Set<string>>
+}
+
+const TRUST_PROFILE_SCHEMAS = [
+  { id: "user-review", label: "Reviews" },
+  { id: "certification", label: "Certifications" },
+  { id: "security-assessment", label: "Security Assessments" },
+  { id: "controller-witness", label: "Controller Witnesses" },
+  { id: "key-binding", label: "Key Bindings" },
+]
+
+function getSubjectType(did: string) {
+  if (did.startsWith("did:web:")) return "Web Domain / URL"
+  if (did.startsWith("did:pkh:")) return "Blockchain Address"
+  if (did.startsWith("did:jwk:")) return "JWK Key"
+  if (did.startsWith("did:handle:")) return "Social Handle"
+  return "DID"
+}
+
+function StatusBadge({ ok, label }: { ok: boolean; label: string }) {
+  return (
+    <Badge variant={ok ? "success" : "destructive"} className="gap-1">
+      {ok ? <CheckCircle2 className="h-3 w-3" /> : <XCircle className="h-3 w-3" />}
+      {label}
+    </Badge>
+  )
+}
+
+function Signal({ active, label }: { active: boolean; label: string }) {
+  return (
+    <span className={`inline-block rounded-full border px-2.5 py-1 text-xs font-medium ${
+      active
+        ? "border-primary/25 bg-primary/10 text-primary"
+        : "border-border bg-background text-muted-foreground"
+    }`}>
+      {label}: {active ? "Yes" : "No"}
+    </span>
+  )
+}
+
+/**
+ * Build key authorization info from the backend controller-confirm response
+ * and the attestation list — same logic as the dashboard's buildServiceKeys.
+ */
+function buildKeyAuthorization(
+  controllerDid: string,
+  subjectDid: string,
+  confirmation: ControllerConfirmResponse,
+  attestations: EnrichedAttestationResult[]
+): KeyAuthorizationInfo {
+  const sources: string[] = []
+  let basic = false
+  let intermediate = false
+  let hasKeyBinding = false
+
+  // Check if the controller is found in the backend's live evidence
+  for (const key of confirmation.controllerKeys) {
+    if (isSameControllerId(key.canonicalId, controllerDid)) {
+      for (const source of key.sources) {
+        const label = source === "dns-txt" ? "DNS TXT"
+          : source === "did-json" ? "DID document"
+          : source === "account-wallet" ? "Account wallet"
+          : source
+        if (!sources.includes(label)) sources.push(label)
+      }
+      basic = key.basic
+      break
+    }
+  }
+
+  // Check attestations for controller witnesses and key bindings
+  for (const att of attestations) {
+    if (att.schemaId === "controller-witness") {
+      const witnessController = att.decodedData?.controller
+      if (typeof witnessController === "string" && isSameControllerId(witnessController, controllerDid)) {
+        intermediate = true
+        if (!sources.includes("Controller witness")) sources.push("Controller witness")
+      }
+    }
+    if (att.schemaId === "key-binding") {
+      const keyId = att.decodedData?.keyId
+      if (typeof keyId === "string" && isSameControllerId(keyId, controllerDid)) {
+        hasKeyBinding = true
+        if (!sources.includes("Key binding")) sources.push("Key binding")
+      }
+    }
+  }
+
+  const advanced = intermediate && hasKeyBinding
+
+  return {
+    subjectDid,
+    controllerDid,
+    sources,
+    basic,
+    intermediate,
+    advanced,
+  }
+}
+
+export default function VerifyPage() {
+  const [subjectDid, setSubjectDid] = useState("")
+  const [controllerDid, setControllerDid] = useState("")
+  const [isVerifying, setIsVerifying] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [result, setResult] = useState<VerifyResult | null>(null)
+
+  const trustProfile = useMemo(() => {
+    const attestations = result?.attestations ?? []
+    return TRUST_PROFILE_SCHEMAS.map((schema) => ({
+      ...schema,
+      count: attestations.filter((attestation) => attestation.schemaId === schema.id).length,
+    }))
+  }, [result?.attestations])
+
+  const handleVerify = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    const subject = subjectDid.trim()
+    const controller = controllerDid.trim()
+
+    if (!subject) {
+      setError("Select a subject to verify.")
+      return
+    }
+
+    setIsVerifying(true)
+    setError(null)
+
+    try {
+      const [attestationsRaw, trustAnchorsResult] = await Promise.allSettled([
+        getVerifiedAttestationsForDIDWithMetadata(subject),
+        getPublicTrustAnchors(),
+      ])
+
+      // If the main attestation query failed, surface the error
+      if (attestationsRaw.status === "rejected") {
+        throw attestationsRaw.reason instanceof Error
+          ? attestationsRaw.reason
+          : new Error("Failed to fetch attestations.")
+      }
+
+      const attestations = sortByCategoryPriority(attestationsRaw.value)
+
+      // Build approved issuers map from trust anchors
+      const approvedIssuers = new Map<string, Set<string>>()
+      if (trustAnchorsResult.status === "fulfilled") {
+        for (const registry of trustAnchorsResult.value.registries) {
+          if (registry.type === "approved-issuers") {
+            for (const issuer of registry.issuers) {
+              if (issuer.status !== "active") continue
+              const key = issuer.address.toLowerCase()
+              const existing = approvedIssuers.get(key) ?? new Set<string>()
+              for (const schema of issuer.schemas) existing.add(schema)
+              approvedIssuers.set(key, existing)
+            }
+          }
+        }
+      }
+
+      let keyAuthorization: KeyAuthorizationInfo | null = null
+      let keyAuthorizationError: string | null = null
+
+      if (controller) {
+        try {
+          const confirmation = await getControllerConfirmation({ subjectDid: subject })
+          keyAuthorization = buildKeyAuthorization(controller, subject, confirmation, attestations)
+        } catch (err) {
+          keyAuthorizationError = err instanceof Error
+            ? err.message
+            : "Controller authorization check failed."
+        }
+      }
+
+      setResult({
+        subjectDid: subject,
+        canonicalDid: subject,
+        attestations,
+        keyAuthorization,
+        keyAuthorizationError,
+        approvedIssuers,
+      })
+    } catch (err) {
+      setResult(null)
+      setError(err instanceof Error ? err.message : "Verification failed.")
+    } finally {
+      setIsVerifying(false)
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-6xl px-4 py-10 sm:px-6 lg:px-8">
+      <div className="mb-8 flex items-center gap-3">
+        <div className="flex h-11 w-11 items-center justify-center rounded-full bg-primary/10 text-primary">
+          <ShieldCheck className="h-5 w-5" />
+        </div>
+        <div>
+          <p className="technical-label text-primary">Trust Verifier</p>
+          <h1 className="text-3xl font-semibold tracking-tight">Verify</h1>
+        </div>
+      </div>
+
+      <form onSubmit={handleVerify} className="rounded-xl border border-border/70 bg-card/70 p-5 shadow-sm shadow-slate-950/5 sm:p-6">
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+          <div>
+            <div className="mb-2 flex items-center justify-between gap-3">
+              <label className="text-sm font-medium text-foreground">Subject</label>
+              <Badge variant="secondary">Required</Badge>
+            </div>
+            <SubjectIdInput
+              value={subjectDid}
+              onChange={(did) => setSubjectDid(did ?? "")}
+              allowedMethods={["web", "pkh", "jwk"]}
+              className="ml-0"
+            />
+          </div>
+
+          <div>
+            <div className="mb-2 flex items-center justify-between gap-3">
+              <label className="text-sm font-medium text-foreground">Signing Key</label>
+              <Badge variant="outline">Optional</Badge>
+            </div>
+            <SubjectIdInput
+              value={controllerDid}
+              onChange={(did) => setControllerDid(did ?? "")}
+              allowedMethods={["jwk", "pkh"]}
+              className="ml-0"
+            />
+          </div>
+        </div>
+
+        {error ? (
+          <div className="mt-5 rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+            {error}
+          </div>
+        ) : null}
+
+        <div className="mt-6 flex justify-end">
+          <Button type="submit" disabled={isVerifying || !subjectDid.trim()}>
+            <Search className="h-4 w-4" />
+            {isVerifying ? "Verifying..." : "Verify"}
+          </Button>
+        </div>
+      </form>
+
+      {result ? (
+        <div className="mt-8 space-y-8">
+          {controllerDid.trim() ? (
+            <section className="rounded-xl border border-border/70 bg-card/70 p-5 shadow-sm shadow-slate-950/5 sm:p-6">
+              <div className="mb-5 flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <p className="technical-label text-primary">Controller Authorization</p>
+                  <h2 className="text-xl font-semibold tracking-tight">Authorization Result</h2>
+                </div>
+                {result.keyAuthorization ? (
+                  <StatusBadge
+                    ok={result.keyAuthorization.basic || result.keyAuthorization.intermediate || result.keyAuthorization.advanced}
+                    label={result.keyAuthorization.basic || result.keyAuthorization.intermediate || result.keyAuthorization.advanced ? "Authorized" : "Not authorized"}
+                  />
+                ) : null}
+              </div>
+
+              {result.keyAuthorizationError ? (
+                <div className="rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+                  {result.keyAuthorizationError}
+                </div>
+              ) : result.keyAuthorization ? (
+                <div className="rounded-xl border border-border/70 bg-background p-4">
+                  <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                    <div className="min-w-0 flex-1 space-y-1">
+                      <p className="text-sm text-foreground break-all">
+                        <span className="font-bold">Service ID:</span>{' '}
+                        <span className="font-mono text-xs">{result.keyAuthorization.subjectDid}</span>
+                      </p>
+                      <p className="text-sm text-foreground break-all">
+                        <span className="font-bold">Key ID:</span>{' '}
+                        <span className="font-mono text-xs">{result.keyAuthorization.controllerDid}</span>
+                      </p>
+                      <p className="mt-2 text-sm font-medium text-foreground/70">
+                        Mechanisms: {result.keyAuthorization.sources.length > 0 ? result.keyAuthorization.sources.join(", ") : "None"}
+                      </p>
+                    </div>
+                    <div className="flex shrink-0 flex-wrap gap-2">
+                      <Signal active={result.keyAuthorization.basic} label="Basic" />
+                      <Signal active={result.keyAuthorization.intermediate} label="Intermediate" />
+                      <Signal active={result.keyAuthorization.advanced} label="Advanced" />
+                    </div>
+                  </div>
+                </div>
+              ) : null}
+            </section>
+          ) : null}
+
+          <section className="rounded-xl border border-border/70 bg-card/70 p-5 shadow-sm shadow-slate-950/5 sm:p-6">
+            <div className="mb-5 flex flex-wrap items-center justify-between gap-3">
+              <div>
+                <p className="technical-label text-primary">Subject Summary</p>
+                <h2 className="text-xl font-semibold tracking-tight">Trust Profile</h2>
+              </div>
+              <Badge variant="secondary">{getSubjectType(result.subjectDid)}</Badge>
+            </div>
+
+            <div className="grid gap-4 lg:grid-cols-2">
+              <div className="min-w-0 rounded-lg border border-border/70 bg-muted/30 p-4">
+                <p className="text-xs font-medium uppercase text-muted-foreground">Subject DID</p>
+                <p className="mt-2 break-all font-mono text-sm">{result.subjectDid}</p>
+              </div>
+              <div className="min-w-0 rounded-lg border border-border/70 bg-muted/30 p-4">
+                <p className="text-xs font-medium uppercase text-muted-foreground">Canonical DID</p>
+                <p className="mt-2 break-all font-mono text-sm">{result.canonicalDid}</p>
+              </div>
+            </div>
+
+            <div className="mt-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+              {trustProfile.map((item) => (
+                <div key={item.id} className="rounded-lg border border-border/70 bg-background/60 p-4">
+                  <p className="text-2xl font-semibold tracking-tight">{item.count}</p>
+                  <p className="mt-1 text-sm text-muted-foreground">{item.label}</p>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section>
+            <div className="mb-3">
+              <p className="technical-label text-primary">Attestations</p>
+            </div>
+            <div className="rounded-xl border border-border/70 bg-card/70 px-4 py-2 shadow-sm shadow-slate-950/5 sm:px-8">
+              <LatestAttestations
+                showHeading={false}
+                data={result.attestations}
+                approvedIssuers={result.approvedIssuers}
+                emptyMessage="No attestations found for this subject."
+              />
+            </div>
+          </section>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/src/components/SubjectIdInput.tsx
+++ b/src/components/SubjectIdInput.tsx
@@ -10,7 +10,7 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { DidWebInput } from "@/components/did-web-input"
-import { Caip10Input } from "@/components/caip10-input"
+import { DidPkhInput } from "@/components/did-pkh-input"
 import { DidHandleInput } from "@/components/did-handle-input"
 import { DidKeyInput } from "@/components/did-key-input"
 import { ArtifactDidInput } from "@/components/artifact-did-input"
@@ -116,16 +116,9 @@ export function SubjectIdInput({
     onChange(did)
   }
 
-  const handleCaip10Change = (caip10: string | null) => {
-    // Convert CAIP-10 to did:pkh format
-    const did = caip10 ? `did:pkh:${caip10}` : null
+  const handleDidPkhChange = (did: string | null) => {
     onChange(did)
   }
-
-  // Extract CAIP-10 from did:pkh for the input
-  const caip10Value = value?.startsWith("did:pkh:") 
-    ? value.replace("did:pkh:", "") 
-    : ""
 
   return (
     <div className={`ml-4 rounded-lg border border-border/70 bg-muted/30 p-4 space-y-4 ${className}`}>
@@ -170,9 +163,9 @@ export function SubjectIdInput({
       )}
 
       {effectiveMethod === "did:pkh" && (
-        <Caip10Input
-          value={caip10Value}
-          onChange={handleCaip10Change}
+        <DidPkhInput
+          value={value}
+          onChange={handleDidPkhChange}
           error={error}
         />
       )}

--- a/src/components/attestation-card.tsx
+++ b/src/components/attestation-card.tsx
@@ -1,11 +1,13 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
-import { Shield, Award, LinkIcon, Star, MessageSquare } from "lucide-react"
+import { Shield, Award, LinkIcon, Star, MessageSquare, CheckCircle2 } from "lucide-react"
 import type { EnrichedAttestationResult } from "@/lib/attestation-queries"
 import { StarRating } from "@/components/star-rating"
 
 interface AttestationCardProps {
   attestation: EnrichedAttestationResult
+  /** When true, shows a "Trusted" badge indicating the attester is an approved issuer in the trust anchors. */
+  trusted?: boolean
   onClick: () => void
 }
 
@@ -18,10 +20,23 @@ const schemaIcons: Record<string, any> = {
   'user-review-response': MessageSquare,
 }
 
-export function AttestationCard({ attestation, onClick }: AttestationCardProps) {
+/** Format check names to be more user-friendly */
+function formatCheckName(name: string, passed: boolean): string {
+  switch (name) {
+    case 'revocation': return passed ? 'Not revoked' : 'Revoked'
+    case 'expiration': return passed ? 'Not expired' : 'Expired'
+    case 'proofs': return passed ? 'Verified' : 'Not verified'
+    default: return name.replace(/([A-Z])/g, ' $1').trim()
+  }
+}
+
+export function AttestationCard({ attestation, trusted, onClick }: AttestationCardProps) {
   const Icon = schemaIcons[attestation.schemaId || ''] || Shield
   const date = new Date(attestation.time * 1000).toLocaleDateString()
   const revoked = attestation.revocationTime > 0
+  const verification = attestation.verification
+  const isUserReview = attestation.schemaId === 'user-review' || attestation.schemaId === 'user-review-response'
+  const isControllerWitness = attestation.schemaId === 'controller-witness'
   
   // Get subject from decoded data if available
   const subject = attestation.decodedData?.subject || attestation.recipient
@@ -41,6 +56,18 @@ export function AttestationCard({ attestation, onClick }: AttestationCardProps) 
             ) : (
               <Badge variant="success">Active</Badge>
             )}
+            {verification?.valid ? (
+              <Badge variant="success" className="gap-1">
+                <CheckCircle2 className="h-3 w-3" />
+                Verified
+              </Badge>
+            ) : null}
+            {trusted ? (
+              <Badge variant="warning" className="gap-1">
+                <CheckCircle2 className="h-3 w-3" />
+                Trusted
+              </Badge>
+            ) : null}
           </div>
           <span className="text-sm text-muted-foreground">{date}</span>
         </div>
@@ -55,12 +82,69 @@ export function AttestationCard({ attestation, onClick }: AttestationCardProps) 
             <span className="font-medium text-foreground">Service ID:</span>{' '}
             <span className="font-mono text-muted-foreground break-all">{subject}</span>
           </div>
+          {isControllerWitness && attestation.decodedData?.controller && (
+            <div>
+              <span className="font-medium text-foreground">Controller:</span>{' '}
+              <span className="font-mono text-muted-foreground break-all">
+                {String(attestation.decodedData.controller)}
+              </span>
+            </div>
+          )}
+          {isControllerWitness && attestation.decodedData?.method && (
+            <div>
+              <span className="font-medium text-foreground">Method:</span>{' '}
+              <span className="text-muted-foreground capitalize">
+                {String(attestation.decodedData.method).replace(/-/g, ' ')}
+              </span>
+            </div>
+          )}
+          {isControllerWitness && attestation.decodedData?.observedAt && (
+            <div>
+              <span className="font-medium text-foreground">Observed:</span>{' '}
+              <span className="text-muted-foreground">
+                {(() => {
+                  const val = attestation.decodedData!.observedAt
+                  const num = typeof val === 'bigint' ? Number(val) : Number(val)
+                  if (!num || num <= 0) return 'Unknown'
+                  const ms = num > 1e12 ? num : num * 1000
+                  return new Date(ms).toLocaleDateString()
+                })()}
+              </span>
+            </div>
+          )}
           {attestation.decodedData?.ratingValue && (
             <div>
               <span className="font-medium text-foreground">Rating:</span>{' '}
               <StarRating value={attestation.decodedData.ratingValue as string | number} />
             </div>
           )}
+          {/* Verification section: show in list for non-user-review schemas only */}
+          {verification && !isUserReview ? (
+            <div className="rounded-md border border-border/70 bg-muted/40 p-3">
+              <div className="mb-1 flex items-center justify-between gap-3">
+                <span className="font-medium text-foreground">Status:</span>
+                <span className={verification.valid ? "text-primary" : "text-muted-foreground"}>
+                  {verification.valid ? "Passed" : "Not verified"}
+                </span>
+              </div>
+              {Object.keys(verification.checks).length > 0 ? (
+                <div className="flex flex-wrap gap-1.5">
+                  {Object.entries(verification.checks).map(([name, passed]) => (
+                    <Badge key={name} variant={passed ? "success" : "secondary"}>
+                      {formatCheckName(name, passed)}
+                    </Badge>
+                  ))}
+                </div>
+              ) : null}
+              {verification.reasons.length > 0 ? (
+                <ul className="mt-2 space-y-1 text-xs text-muted-foreground">
+                  {verification.reasons.map((reason) => (
+                    <li key={reason}>{reason}</li>
+                  ))}
+                </ul>
+              ) : null}
+            </div>
+          ) : null}
         </div>
       </CardContent>
     </Card>

--- a/src/components/attestation-detail-modal.tsx
+++ b/src/components/attestation-detail-modal.tsx
@@ -7,6 +7,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
+import { Badge } from "@/components/ui/badge"
 import type { EnrichedAttestationResult } from "@/lib/attestation-queries"
 import { Shield, Award, LinkIcon, Star, MessageSquare, ExternalLink } from "lucide-react"
 import { getActiveChain } from "@/lib/blockchain"
@@ -57,6 +58,16 @@ const FIELD_LABEL_MAP: Record<string, string> = {
 function getFieldLabel(key: string): string {
   if (FIELD_LABEL_MAP[key]) return FIELD_LABEL_MAP[key]
   return key.replace(/([A-Z])/g, ' $1').trim()
+}
+
+/** Format check names to be more user-friendly */
+function formatCheckName(name: string, passed: boolean): string {
+  switch (name) {
+    case 'revocation': return passed ? 'Not revoked' : 'Revoked'
+    case 'expiration': return passed ? 'Not expired' : 'Expired'
+    case 'proofs': return passed ? 'Verified' : 'Not verified'
+    default: return name.replace(/([A-Z])/g, ' $1').trim()
+  }
 }
 
 // Format observedAt timestamps to human-readable dates
@@ -173,6 +184,37 @@ export function AttestationDetailModal({ isOpen, onClose, attestation }: Attesta
               {new Date(attestation.expirationTime * 1000).toLocaleString()}
             </div>
           )}
+
+          {/* Verification Status */}
+          {attestation.verification ? (
+            <div className="space-y-3">
+              <h3 className="font-semibold tracking-tight text-foreground">Status</h3>
+              <div className="rounded-lg border border-border/70 bg-muted/50 p-4">
+                <div className="mb-2 flex items-center justify-between gap-3">
+                  <span className="font-medium text-foreground">Overall:</span>
+                  <span className={attestation.verification.valid ? "text-primary font-medium" : "text-muted-foreground"}>
+                    {attestation.verification.valid ? "Passed" : "Not verified"}
+                  </span>
+                </div>
+                {Object.keys(attestation.verification.checks).length > 0 ? (
+                  <div className="flex flex-wrap gap-1.5">
+                    {Object.entries(attestation.verification.checks).map(([name, passed]) => (
+                      <Badge key={name} variant={passed ? "success" : "secondary"}>
+                        {formatCheckName(name, passed)}
+                      </Badge>
+                    ))}
+                  </div>
+                ) : null}
+                {attestation.verification.reasons.length > 0 ? (
+                  <ul className="mt-2 space-y-1 text-xs text-muted-foreground">
+                    {attestation.verification.reasons.map((reason) => (
+                      <li key={reason}>{reason}</li>
+                    ))}
+                  </ul>
+                ) : null}
+              </div>
+            </div>
+          ) : null}
 
         </div>
       </DialogContent>

--- a/src/components/did-pkh-input.tsx
+++ b/src/components/did-pkh-input.tsx
@@ -1,0 +1,362 @@
+"use client"
+
+import React, { useState, useEffect, useRef } from "react"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Button } from "@/components/ui/button"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  ChevronDownIcon,
+  ChevronUpIcon,
+  CheckIcon,
+  AlertCircleIcon,
+} from "lucide-react"
+import { normalizeCaip10 } from "@/lib/utils/caip10/normalize"
+import { buildCaip10 } from "@/lib/utils/caip10/parse"
+import { NON_EVM_CAIP2 } from "@/lib/utils/caip10/chains"
+import { ChainSearchInput } from "@/components/chain-search-input"
+
+type Ecosystem = "eip155" | "solana" | "sui"
+
+interface DidPkhInputProps {
+  value?: string
+  onChange: (did: string | null) => void
+  className?: string
+  error?: string
+}
+
+/** Parse a did:pkh string into its CAIP-10 components */
+function parseDidPkh(did: string): { namespace: string; reference: string; address: string } | null {
+  const match = did.match(/^did:pkh:([a-z0-9]+):([^:]+):(.+)$/)
+  if (!match) return null
+  return { namespace: match[1], reference: match[2], address: match[3] }
+}
+
+/**
+ * DID:PKH Input Component
+ *
+ * Top-level field accepts a full did:pkh:... string (paste-friendly).
+ * A collapsible builder lets users construct the DID by picking
+ * ecosystem, chain, and address without knowing CAIP-10 internals.
+ */
+export function DidPkhInput({
+  value = "",
+  onChange,
+  className = "",
+  error: externalError,
+}: DidPkhInputProps) {
+  // Top-level DID text
+  const [inputValue, setInputValue] = useState(value)
+  const [validationError, setValidationError] = useState<string | null>(null)
+  const [isValid, setIsValid] = useState(false)
+
+  // Builder state
+  const [builderOpen, setBuilderOpen] = useState(false)
+  const [ecosystem, setEcosystem] = useState<Ecosystem>("eip155")
+  const [evmChainId, setEvmChainId] = useState<number | null>(null)
+  const [solanaRef, setSolanaRef] = useState<string>(NON_EVM_CAIP2.solana.mainnetRef)
+  const [suiRef, setSuiRef] = useState<string>(NON_EVM_CAIP2.sui.mainnetRef)
+  const [address, setAddress] = useState("")
+
+  const builderRef = useRef<HTMLDivElement>(null)
+  const debounceRef = useRef<NodeJS.Timeout | null>(null)
+
+  // Sync with external value prop (e.g. pre-fill from dashboard)
+  useEffect(() => {
+    if (value !== inputValue) {
+      setInputValue(value)
+      syncBuilderFromDid(value)
+    }
+  }, [value])
+
+  // Validate whenever inputValue changes
+  useEffect(() => {
+    validateInput(inputValue)
+  }, [inputValue])
+
+  // Auto-scroll when builder opens
+  useEffect(() => {
+    if (builderOpen && builderRef.current) {
+      setTimeout(() => {
+        builderRef.current?.scrollIntoView({ behavior: "smooth", block: "nearest" })
+      }, 100)
+    }
+  }, [builderOpen])
+
+  function syncBuilderFromDid(did: string) {
+    const parsed = parseDidPkh(did)
+    if (!parsed) return
+
+    const { namespace, reference, address: addr } = parsed
+    if (namespace === "eip155") {
+      setEcosystem("eip155")
+      setEvmChainId(parseInt(reference, 10))
+    } else if (namespace === "solana") {
+      setEcosystem("solana")
+      setSolanaRef(reference)
+    } else if (namespace === "sui") {
+      setEcosystem("sui")
+      setSuiRef(reference)
+    }
+    setAddress(addr)
+  }
+
+  function validateInput(did: string) {
+    if (!did.trim()) {
+      setIsValid(false)
+      setValidationError(null)
+      return
+    }
+
+    // Must start with did:pkh:
+    if (!did.startsWith("did:pkh:")) {
+      setIsValid(false)
+      setValidationError("Must start with did:pkh:")
+      return
+    }
+
+    // Extract CAIP-10 portion and validate
+    const caip10 = did.replace("did:pkh:", "")
+    const result = normalizeCaip10(caip10)
+
+    if (result.valid) {
+      setIsValid(true)
+      setValidationError(null)
+    } else {
+      setIsValid(false)
+      setValidationError(result.error || "Invalid address format")
+    }
+  }
+
+  // Debounced onChange for top-level input typing
+  function handleTopInputChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const newValue = e.target.value
+    setInputValue(newValue)
+
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+
+    debounceRef.current = setTimeout(() => {
+      emitValue(newValue)
+    }, 1500)
+  }
+
+  function handleTopInputBlur() {
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    emitValue(inputValue)
+  }
+
+  function emitValue(did: string) {
+    if (!did.trim()) {
+      onChange(null)
+      return
+    }
+
+    if (!did.startsWith("did:pkh:")) {
+      onChange(null)
+      return
+    }
+
+    const caip10 = did.replace("did:pkh:", "")
+    const result = normalizeCaip10(caip10)
+
+    if (result.valid && result.normalized) {
+      const normalized = `did:pkh:${result.normalized}`
+      setInputValue(normalized)
+      onChange(normalized)
+    } else {
+      onChange(null)
+    }
+  }
+
+  function handleBuilderApply() {
+    let reference = ""
+
+    switch (ecosystem) {
+      case "eip155":
+        if (evmChainId === null || !address) return
+        reference = evmChainId.toString()
+        break
+      case "solana":
+        if (!address) return
+        reference = solanaRef
+        break
+      case "sui":
+        if (!address) return
+        reference = suiRef
+        break
+    }
+
+    const caip10 = buildCaip10(ecosystem, reference, address)
+    const result = normalizeCaip10(caip10)
+
+    if (result.valid && result.normalized) {
+      const did = `did:pkh:${result.normalized}`
+      setInputValue(did)
+      onChange(did)
+      setBuilderOpen(false)
+    } else {
+      // Show validation from builder attempt
+      setValidationError(result.error || "Invalid address")
+    }
+  }
+
+  const showError = externalError || (validationError && inputValue.trim())
+  const errorMessage = externalError || validationError
+
+  return (
+    <div className={`space-y-3 ${className}`}>
+      {/* Primary DID input */}
+      <div className="grid gap-2">
+        <Label htmlFor="did-pkh-input">Blockchain DID</Label>
+        <Input
+          id="did-pkh-input"
+          value={inputValue}
+          onChange={handleTopInputChange}
+          onBlur={handleTopInputBlur}
+          placeholder="did:pkh:eip155:1:0xAbc123..."
+          className={showError ? "field-error" : ""}
+        />
+
+        {showError && (
+          <div className="feedback-error">
+            <AlertCircleIcon size={16} className="mt-0.5 flex-shrink-0" />
+            <span>{errorMessage}</span>
+          </div>
+        )}
+
+        {isValid && inputValue.trim() && (
+          <div className="feedback-success">
+            <CheckIcon size={16} className="mt-0.5 flex-shrink-0" />
+            <span>Valid blockchain DID</span>
+          </div>
+        )}
+      </div>
+
+      {/* Collapsible Builder */}
+      <div ref={builderRef} className="border rounded-md">
+        <button
+          type="button"
+          onClick={() => setBuilderOpen(!builderOpen)}
+          className="w-full px-4 py-3 flex items-center justify-between hover:bg-muted/50 transition-colors"
+        >
+          <span className="text-sm font-medium">Build DID from chain &amp; address</span>
+          {builderOpen ? <ChevronUpIcon size={16} /> : <ChevronDownIcon size={16} />}
+        </button>
+
+        {builderOpen && (
+          <div className="p-4 border-t space-y-4">
+            {/* Ecosystem / VM selector */}
+            <div className="grid gap-2">
+              <Label htmlFor="ecosystem">Virtual Machine</Label>
+              <Select value={ecosystem} onValueChange={(v) => setEcosystem(v as Ecosystem)}>
+                <SelectTrigger id="ecosystem">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="eip155">EVM (Ethereum, Base, OMAChain, etc.)</SelectItem>
+                  <SelectItem value="solana">Solana</SelectItem>
+                  <SelectItem value="sui">Sui</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            {/* Chain selector — EVM */}
+            {ecosystem === "eip155" && (
+              <div className="grid gap-2">
+                <Label htmlFor="evm-chain">Chain</Label>
+                <div className="space-y-2">
+                  <ChainSearchInput
+                    value={evmChainId}
+                    onChange={(chainId) => setEvmChainId(chainId)}
+                    placeholder="Search by chain name or ID..."
+                  />
+                  <div className="text-xs text-muted-foreground">
+                    Chain not listed? Enter its ID manually:
+                  </div>
+                  <Input
+                    type="number"
+                    value={evmChainId ?? ""}
+                    onChange={(e) => {
+                      const val = e.target.value
+                      setEvmChainId(val ? parseInt(val, 10) : null)
+                    }}
+                    placeholder="e.g. 6623 for OMAChain"
+                    className="font-mono"
+                  />
+                </div>
+              </div>
+            )}
+
+            {/* Chain selector — Solana */}
+            {ecosystem === "solana" && (
+              <div className="grid gap-2">
+                <Label htmlFor="solana-network">Network</Label>
+                <Select value={solanaRef} onValueChange={setSolanaRef}>
+                  <SelectTrigger id="solana-network">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={NON_EVM_CAIP2.solana.mainnetRef}>Mainnet</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+
+            {/* Chain selector — Sui */}
+            {ecosystem === "sui" && (
+              <div className="grid gap-2">
+                <Label htmlFor="sui-network">Network</Label>
+                <Select value={suiRef} onValueChange={setSuiRef}>
+                  <SelectTrigger id="sui-network">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={NON_EVM_CAIP2.sui.mainnetRef}>Mainnet</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+
+            {/* Address field */}
+            <div className="grid gap-2">
+              <Label htmlFor="builder-address">Address</Label>
+              <Input
+                id="builder-address"
+                value={address}
+                onChange={(e) => setAddress(e.target.value)}
+                placeholder={
+                  ecosystem === "eip155"
+                    ? "0x1234567890abcdef..."
+                    : ecosystem === "solana"
+                    ? "TokenkegQfeZyiNw..."
+                    : "0x000...001"
+                }
+              />
+              <p className="text-xs text-muted-foreground">
+                {ecosystem === "eip155" && "The contract or wallet address (0x + 40 hex characters)."}
+                {ecosystem === "solana" && "Base58-encoded 32-byte public key."}
+                {ecosystem === "sui" && "Hex address (0x + up to 64 chars). Short forms are padded."}
+              </p>
+            </div>
+
+            {/* Apply */}
+            <Button
+              type="button"
+              onClick={handleBuilderApply}
+              disabled={!address || (ecosystem === "eip155" && evmChainId === null)}
+              className="w-full"
+            >
+              Use this address
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -17,6 +17,7 @@ type NavLink = {
 
 const navLinks: NavLink[] = [
   { label: "Activity", href: "/" },
+  { label: "Verify", href: "/verify" },
   { label: "Dashboard", href: "/dashboard" },
   { label: "Docs", href: "https://docs.omatrust.org/", external: true },
 ]
@@ -82,6 +83,7 @@ export function Header() {
   return (
     <>
       <nav
+        suppressHydrationWarning
         className={`sticky top-0 z-50 transition-all duration-500 ${
         scrolled
           ? "bg-background/80 backdrop-blur-xl border-b border-border"

--- a/src/components/latest-attestations.tsx
+++ b/src/components/latest-attestations.tsx
@@ -8,13 +8,24 @@ import { useWallet } from '@/lib/blockchain'
 import logger from '@/lib/logger'
 import { ATTESTATION_QUERY_CONFIG } from '@/config/attestation-services'
 
+/** Set of schema IDs eligible for the "Trusted" badge when attested by an approved issuer. */
+const TRUSTED_BADGE_SCHEMAS = new Set(['security-assessment', 'certification'])
+
 interface LatestAttestationsProps {
   showHeading?: boolean
   /** Pre-fetched attestation data. When provided, the component skips its own fetch. */
   data?: EnrichedAttestationResult[]
+  emptyMessage?: string
+  /** Approved issuer addresses (lowercased) mapped to their approved schema IDs. */
+  approvedIssuers?: Map<string, Set<string>>
 }
 
-export function LatestAttestations({ showHeading = true, data }: LatestAttestationsProps) {
+export function LatestAttestations({
+  showHeading = true,
+  data,
+  emptyMessage = 'No attestations found yet. Be the first to submit one!',
+  approvedIssuers,
+}: LatestAttestationsProps) {
   const [attestations, setAttestations] = useState<EnrichedAttestationResult[]>(data ?? [])
   const [isLoading, setIsLoading] = useState(!data)
   const [error, setError] = useState<string | null>(null)
@@ -96,7 +107,7 @@ export function LatestAttestations({ showHeading = true, data }: LatestAttestati
           <h2 className="mb-8 text-center text-3xl font-semibold tracking-tight">Latest Attestations</h2>
         ) : null}
         <div className="text-center text-muted-foreground">
-          <p>No attestations found yet. Be the first to submit one!</p>
+          <p>{emptyMessage}</p>
         </div>
       </div>
     )
@@ -109,13 +120,22 @@ export function LatestAttestations({ showHeading = true, data }: LatestAttestati
           <h2 className="mb-8 text-center text-3xl font-semibold tracking-tight">Latest Attestations</h2>
         ) : null}
         <div className="grid grid-cols-1 gap-4 max-w-4xl mx-auto">
-          {attestations.map((attestation) => (
-            <AttestationCard 
-              key={attestation.uid} 
-              attestation={attestation}
-              onClick={() => handleCardClick(attestation)}
-            />
-          ))}
+          {attestations.map((attestation) => {
+            const isTrusted = !!(
+              approvedIssuers &&
+              attestation.schemaId &&
+              TRUSTED_BADGE_SCHEMAS.has(attestation.schemaId) &&
+              approvedIssuers.get(attestation.attester.toLowerCase())?.has(attestation.schemaId)
+            )
+            return (
+              <AttestationCard 
+                key={attestation.uid} 
+                attestation={attestation}
+                trusted={isTrusted}
+                onClick={() => handleCardClick(attestation)}
+              />
+            )
+          })}
         </div>
       </div>
 

--- a/src/components/subject-confirmation-dialog.tsx
+++ b/src/components/subject-confirmation-dialog.tsx
@@ -18,7 +18,7 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { DidWebInput } from "@/components/did-web-input"
-import { Caip10Input } from "@/components/caip10-input"
+import { DidPkhInput } from "@/components/did-pkh-input"
 import {
   BackendApiError,
   createSubject,
@@ -114,7 +114,6 @@ export function SubjectConfirmationDialog({
     return inferred || selectedMethod
   }, [selectedMethod, subjectDid])
 
-  const caip10Value = subjectDid.startsWith("did:pkh:") ? subjectDid.replace("did:pkh:", "") : ""
   const subjectDomain = extractDidWebDomain(subjectDid)
   const normalizedExistingDids = useMemo(
     () => new Set(existingSubjectDids.map((did) => did.toLowerCase())),
@@ -250,9 +249,9 @@ export function SubjectConfirmationDialog({
     }
 
     return (
-      <Caip10Input
-        value={caip10Value}
-        onChange={(caip10) => setDidValue(caip10 ? `did:pkh:${caip10}` : null)}
+      <DidPkhInput
+        value={subjectDid}
+        onChange={(did) => setDidValue(did)}
       />
     )
   }

--- a/src/lib/attestation-queries.ts
+++ b/src/lib/attestation-queries.ts
@@ -6,7 +6,11 @@
  */
 
 import * as reputation from '@oma3/omatrust/reputation'
-import type { Hex, AttestationQueryResult as SdkAttestationQueryResult } from '@oma3/omatrust/reputation'
+import type {
+    Hex,
+    AttestationQueryResult as SdkAttestationQueryResult,
+    VerifyAttestationResult,
+} from '@oma3/omatrust/reputation'
 import logger from './logger'
 import { ethers } from 'ethers'
 import { getAllSchemas, type AttestationSchema } from '@/config/schemas'
@@ -37,7 +41,13 @@ export interface EnrichedAttestationResult {
     schemaId?: string
     schemaTitle?: string
     decodedData?: Record<string, any>
+    verification?: VerifyAttestationResult
 }
+
+const PROOF_VERIFICATION_SCHEMA_IDS = new Set([
+    'user-review',
+    'user-review-response',
+])
 
 // ============================================================================
 // Helpers
@@ -47,7 +57,7 @@ export interface EnrichedAttestationResult {
  * Create a provider and resolve the EAS contract address for a given chain.
  * Uses getChainById to look up the RPC URL so we don't hardcode any chain.
  */
-function getProviderAndEas(chainId: number) {
+export function getProviderAndEas(chainId: number) {
     const easContractAddress = getContractAddress('eas', chainId)
     if (!easContractAddress) throw new Error(`EAS not deployed on chain ${chainId}`)
 
@@ -63,6 +73,12 @@ function findSchemaByUid(uid: string, chainId: number): AttestationSchema | unde
     return getAllSchemas().find(s => s.deployedUIDs?.[chainId] === uid)
 }
 
+function getDeployedSchemaUids(chainId: number): Hex[] {
+    return getAllSchemas()
+        .map(s => s.deployedUIDs?.[chainId])
+        .filter((uid): uid is string => !!uid && uid !== '0x'.padEnd(66, '0')) as Hex[]
+}
+
 /**
  * Convert an SDK attestation result to the frontend's enriched type,
  * adding schema metadata and decoded data when available.
@@ -70,7 +86,8 @@ function findSchemaByUid(uid: string, chainId: number): AttestationSchema | unde
 function toFrontendResult(
     att: SdkAttestationQueryResult,
     chainId: number,
-    schema?: AttestationSchema
+    schema?: AttestationSchema,
+    verification?: VerifyAttestationResult
 ): EnrichedAttestationResult {
     let decodedData = att.data as Record<string, any> | undefined
     if (schema?.easSchemaString && att.raw) {
@@ -96,7 +113,30 @@ function toFrontendResult(
         schemaId: schema?.id,
         schemaTitle: schema?.title,
         decodedData,
+        verification,
     }
+}
+
+async function verifySdkAttestation(
+    attestation: SdkAttestationQueryResult,
+    provider: unknown
+): Promise<VerifyAttestationResult> {
+    try {
+        return await reputation.verifyAttestation({
+            attestation,
+            provider,
+        })
+    } catch (error) {
+        return {
+            valid: false,
+            checks: {},
+            reasons: [error instanceof Error ? error.message : 'Verification failed'],
+        }
+    }
+}
+
+function shouldRunProofVerification(schema?: AttestationSchema) {
+    return schema?.id ? PROOF_VERIFICATION_SCHEMA_IDS.has(schema.id) : false
 }
 
 // ============================================================================
@@ -144,10 +184,7 @@ export async function getAllAttestationsForDIDWithMetadata(
     const chainId = getActiveChain().id
     const { provider, easContractAddress } = getProviderAndEas(chainId)
 
-    const schemas = getAllSchemas()
-    const deployedSchemaUids = schemas
-        .map(s => s.deployedUIDs?.[chainId])
-        .filter((uid): uid is string => !!uid && uid !== '0x'.padEnd(66, '0')) as Hex[]
+    const deployedSchemaUids = getDeployedSchemaUids(chainId)
 
     if (deployedSchemaUids.length === 0) {
         return []
@@ -175,6 +212,47 @@ export async function getAllAttestationsForDIDWithMetadata(
 }
 
 /**
+ * Query all attestations for a DID and run SDK verification for each result.
+ * Used by the Trust Verifier page while preserving the same enriched shape
+ * consumed by activity cards.
+ */
+export async function getVerifiedAttestationsForDIDWithMetadata(
+    did: string,
+    limit: number = 100
+): Promise<EnrichedAttestationResult[]> {
+    const chainId = getActiveChain().id
+    const { provider, easContractAddress } = getProviderAndEas(chainId)
+    const deployedSchemaUids = getDeployedSchemaUids(chainId)
+
+    if (deployedSchemaUids.length === 0) {
+        return []
+    }
+
+    const results = await reputation.listAttestations({
+        subjectDid: did,
+        provider,
+        easContractAddress,
+        schemas: deployedSchemaUids,
+        limit,
+    })
+
+    return Promise.all(results.map(async att => {
+        const schema = findSchemaByUid(att.schema, chainId)
+        let enriched = att
+        if (schema?.easSchemaString && att.raw) {
+            try {
+                const decoded = reputation.decodeAttestationData(schema.easSchemaString, att.raw)
+                enriched = { ...att, data: decoded }
+            } catch (err) { logger.warn('[Query] Failed to decode attestation data', att.uid, err) }
+        }
+        const verification = shouldRunProofVerification(schema)
+            ? await verifySdkAttestation(enriched, provider)
+            : undefined
+        return toFrontendResult(enriched, chainId, schema, verification)
+    }))
+}
+
+/**
  * Get latest attestations across all deployed schemas, enriched with
  * schema metadata (schemaId, schemaTitle, decodedData).
  *
@@ -187,10 +265,7 @@ export async function getLatestAttestationsWithMetadata(
 ): Promise<EnrichedAttestationResult[]> {
     const { provider, easContractAddress } = getProviderAndEas(chainId)
 
-    const schemas = getAllSchemas()
-    const deployedSchemaUids = schemas
-        .map(s => s.deployedUIDs?.[chainId])
-        .filter((uid): uid is string => !!uid && uid !== '0x'.padEnd(66, '0')) as Hex[]
+    const deployedSchemaUids = getDeployedSchemaUids(chainId)
 
     if (deployedSchemaUids.length === 0) {
         logger.log('[Query] No schemas deployed on chain', chainId)
@@ -218,6 +293,54 @@ export async function getLatestAttestationsWithMetadata(
     })
 }
 
+// ============================================================================
+// Category Priority Sorting
+// ============================================================================
+
+/**
+ * Schema priority order for the verify page — most important trust signals first.
+ * Schemas not in this list get a default middle priority.
+ */
+const SCHEMA_PRIORITY: Record<string, number> = {
+  'security-assessment': 0,
+  'certification': 1,
+  'controller-witness': 2,
+  'key-binding': 3,
+  'linked-identifier': 4,
+  'user-review-response': 5,
+  'user-review': 6,
+}
+
+const DEFAULT_PRIORITY = 4
+
+/**
+ * Sort attestations by category priority (most important first).
+ * Within the same category, attestations are sorted by time descending (newest first).
+ * User reviews are capped at `reviewLimit` entries.
+ */
+export function sortByCategoryPriority(
+    attestations: EnrichedAttestationResult[],
+    reviewLimit: number = 20
+): EnrichedAttestationResult[] {
+    const sorted = [...attestations].sort((a, b) => {
+        const priorityA = SCHEMA_PRIORITY[a.schemaId ?? ''] ?? DEFAULT_PRIORITY
+        const priorityB = SCHEMA_PRIORITY[b.schemaId ?? ''] ?? DEFAULT_PRIORITY
+        if (priorityA !== priorityB) return priorityA - priorityB
+        // Within same category, newest first
+        return b.time - a.time
+    })
+
+    // Cap user reviews
+    let reviewCount = 0
+    return sorted.filter(att => {
+        if (att.schemaId === 'user-review') {
+            reviewCount++
+            return reviewCount <= reviewLimit
+        }
+        return true
+    })
+}
+
 /**
  * Query attestations created by a specific attester wallet address.
  * Used by the "My Attestations" dashboard page.
@@ -229,10 +352,7 @@ export async function getAttestationsByAttesterWithMetadata(
 ): Promise<EnrichedAttestationResult[]> {
     const { provider, easContractAddress } = getProviderAndEas(chainId)
 
-    const schemas = getAllSchemas()
-    const deployedSchemaUids = schemas
-        .map(s => s.deployedUIDs?.[chainId])
-        .filter((uid): uid is string => !!uid && uid !== '0x'.padEnd(66, '0')) as Hex[]
+    const deployedSchemaUids = getDeployedSchemaUids(chainId)
 
     if (deployedSchemaUids.length === 0) {
         logger.log('[Query] No schemas deployed on chain', chainId)

--- a/tests/app/verify/page.test.tsx
+++ b/tests/app/verify/page.test.tsx
@@ -1,0 +1,158 @@
+import React from 'react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockGetVerifiedAttestations = vi.fn()
+const mockGetControllerConfirmation = vi.fn()
+
+vi.mock('@oma3/omatrust/identity', () => ({
+  isSameControllerId: (a: string, b: string) => a.toLowerCase() === b.toLowerCase(),
+}))
+
+vi.mock('@/lib/blockchain', () => ({
+  getActiveChain: () => ({
+    id: 66238,
+    rpc: 'https://rpc.testnet.chain.oma3.org/',
+    name: 'OMAChain Testnet',
+    nativeCurrency: { name: 'OMA', symbol: 'OMA', decimals: 18 },
+    blockExplorers: [],
+  }),
+}))
+
+vi.mock('@/lib/attestation-queries', () => ({
+  getVerifiedAttestationsForDIDWithMetadata: (...args: unknown[]) => mockGetVerifiedAttestations(...args),
+  sortByCategoryPriority: (attestations: unknown[]) => attestations,
+}))
+
+vi.mock('@/lib/omatrust-backend', () => ({
+  getControllerConfirmation: (...args: unknown[]) => mockGetControllerConfirmation(...args),
+  getPublicTrustAnchors: () => Promise.resolve({ version: 1, updatedAt: '', widgetOrigins: [], chains: {}, registries: [] }),
+}))
+
+vi.mock('@/components/SubjectIdInput', () => ({
+  SubjectIdInput: ({
+    value,
+    onChange,
+    allowedMethods,
+  }: {
+    value: string
+    onChange: (value: string | null) => void
+    allowedMethods?: string[]
+  }) => (
+    <input
+      aria-label={allowedMethods?.includes('web') ? 'Subject DID' : 'Controller DID'}
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+    />
+  ),
+}))
+
+vi.mock('@/components/latest-attestations', () => ({
+  LatestAttestations: ({ data, emptyMessage }: { data: unknown[]; emptyMessage: string }) => (
+    <div data-testid="latest-attestations">
+      {data.length > 0 ? `${data.length} attestations` : emptyMessage}
+    </div>
+  ),
+}))
+
+import VerifyPage from '@/app/verify/page'
+
+const attestation = {
+  uid: `0x${'1'.repeat(64)}`,
+  schema: `0x${'2'.repeat(64)}`,
+  attester: `0x${'a'.repeat(40)}`,
+  recipient: `0x${'b'.repeat(40)}`,
+  data: '0x',
+  time: 1,
+  expirationTime: 0,
+  revocationTime: 0,
+  refUID: `0x${'0'.repeat(64)}`,
+  revocable: true,
+  schemaId: 'certification',
+  schemaTitle: 'Certification',
+  verification: {
+    valid: true,
+    checks: { schema: true },
+    reasons: [],
+  },
+}
+
+describe('Verify page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetVerifiedAttestations.mockResolvedValue([attestation])
+    mockGetControllerConfirmation.mockResolvedValue({
+      subject: { did: 'did:web:example.com', label: 'example.com' },
+      domain: 'example.com',
+      controllerKeys: [
+        {
+          id: 'did:pkh:eip155:66238:0x123',
+          canonicalId: 'did:pkh:eip155:66238:0x123',
+          label: '0x123',
+          sources: ['dns-txt'],
+          basic: true,
+        },
+      ],
+      evidence: [],
+      approvedIssuer: { status: 'not-configured', checkedIdentifiers: [], registryUrl: null },
+      warnings: [],
+    })
+  })
+
+  it('verifies a subject without controller input', async () => {
+    render(<VerifyPage />)
+
+    fireEvent.change(screen.getByLabelText('Subject DID'), {
+      target: { value: 'did:web:example.com' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /verify/i }))
+
+    await waitFor(() => {
+      expect(mockGetVerifiedAttestations).toHaveBeenCalledWith('did:web:example.com')
+    })
+
+    expect(mockGetControllerConfirmation).not.toHaveBeenCalled()
+    expect(screen.getByText('Trust Profile')).toBeInTheDocument()
+    expect(screen.getByText('1 attestations')).toBeInTheDocument()
+    expect(screen.getByText('Certifications')).toBeInTheDocument()
+  })
+
+  it('renders controller authorization when controller input is provided', async () => {
+    render(<VerifyPage />)
+
+    fireEvent.change(screen.getByLabelText('Subject DID'), {
+      target: { value: 'did:web:example.com' },
+    })
+    fireEvent.change(screen.getByLabelText('Controller DID'), {
+      target: { value: 'did:pkh:eip155:66238:0x123' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /verify/i }))
+
+    await waitFor(() => {
+      expect(mockGetControllerConfirmation).toHaveBeenCalledWith({
+        subjectDid: 'did:web:example.com',
+      })
+    })
+
+    expect(screen.getByText('Authorization Result')).toBeInTheDocument()
+    expect(screen.getByText('Authorized')).toBeInTheDocument()
+    expect(screen.getByText(/Basic:/)).toBeInTheDocument()
+    expect(screen.getByText(/Intermediate:/)).toBeInTheDocument()
+    expect(screen.getByText(/Advanced:/)).toBeInTheDocument()
+    expect(screen.getByText(/DNS TXT/)).toBeInTheDocument()
+  })
+
+  it('shows an error when subject verification fails', async () => {
+    mockGetVerifiedAttestations.mockRejectedValueOnce(new Error('Query failed'))
+    render(<VerifyPage />)
+
+    fireEvent.change(screen.getByLabelText('Subject DID'), {
+      target: { value: 'did:web:example.com' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /verify/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Query failed')).toBeInTheDocument()
+    })
+  })
+})

--- a/tests/components/SubjectIdInput.test.tsx
+++ b/tests/components/SubjectIdInput.test.tsx
@@ -35,11 +35,11 @@ vi.mock('@/components/did-web-input', () => ({
     </div>
   ),
 }));
-vi.mock('@/components/caip10-input', () => ({
-  Caip10Input: ({ value, onChange }: { value?: string; onChange: (v: string | null) => void }) => (
-    <div data-testid="caip10-input">
+vi.mock('@/components/did-pkh-input', () => ({
+  DidPkhInput: ({ value, onChange }: { value?: string; onChange: (v: string | null) => void }) => (
+    <div data-testid="did-pkh-input">
       <input
-        aria-label="caip10"
+        aria-label="did:pkh"
         value={value ?? ''}
         onChange={(e) => onChange(e.target.value || null)}
       />
@@ -121,20 +121,20 @@ describe('SubjectIdInput', () => {
     expect(screen.getByTestId('did-web-input')).toBeInTheDocument();
   });
 
-  it('shows Caip10Input when did:pkh is selected', () => {
+  it('shows DidPkhInput when did:pkh is selected', () => {
     const onChange = vi.fn();
     render(<SubjectIdInput onChange={onChange} />);
     const select = screen.getByTestId('subject-method-select');
     fireEvent.change(select, { target: { value: 'did:pkh' } });
-    expect(screen.getByTestId('caip10-input')).toBeInTheDocument();
+    expect(screen.getByTestId('did-pkh-input')).toBeInTheDocument();
   });
 
-  it('calls onChange with did:pkh when caip10 value is entered', () => {
+  it('calls onChange with did:pkh value when entered', () => {
     const onChange = vi.fn();
     render(<SubjectIdInput onChange={onChange} />);
     fireEvent.change(screen.getByTestId('subject-method-select'), { target: { value: 'did:pkh' } });
-    const input = screen.getByLabelText('caip10');
-    fireEvent.change(input, { target: { value: 'eip155:1:0xabc' } });
+    const input = screen.getByLabelText('did:pkh');
+    fireEvent.change(input, { target: { value: 'did:pkh:eip155:1:0xabc' } });
     expect(onChange).toHaveBeenCalledWith('did:pkh:eip155:1:0xabc');
   });
 
@@ -184,12 +184,12 @@ describe('SubjectIdInput', () => {
     expect(onChange).toHaveBeenCalledWith('did:web:newdomain.com');
   });
 
-  it('extracts caip10 value from did:pkh format', () => {
+  it('passes did:pkh value directly to DidPkhInput', () => {
     const onChange = vi.fn();
     render(<SubjectIdInput value="did:pkh:eip155:1:0xabc" onChange={onChange} />);
-    expect(screen.getByTestId('caip10-input')).toBeInTheDocument();
-    const input = screen.getByLabelText('caip10');
-    expect(input).toHaveValue('eip155:1:0xabc');
+    expect(screen.getByTestId('did-pkh-input')).toBeInTheDocument();
+    const input = screen.getByLabelText('did:pkh');
+    expect(input).toHaveValue('did:pkh:eip155:1:0xabc');
   });
 
   it('shows empty caip10 value for non-did:pkh values', () => {

--- a/tests/lib/attestation-queries.test.ts
+++ b/tests/lib/attestation-queries.test.ts
@@ -4,10 +4,12 @@ import * as schemas from '@/config/schemas';
 import * as chains from '@/config/chains';
 import {
   getAttestationsForDIDWithMetadata,
+  getVerifiedAttestationsForDIDWithMetadata,
   getLatestAttestationsWithMetadata,
   getAttestationsByAttesterWithMetadata,
   type EnrichedAttestationResult,
 } from '@/lib/attestation-queries';
+import * as reputation from '@oma3/omatrust/reputation';
 
 vi.mock('@/config/attestation-services', () => ({
   getContractAddress: vi.fn(),
@@ -22,6 +24,8 @@ vi.mock('@oma3/omatrust/reputation', () => ({
   decodeAttestationData: vi.fn().mockReturnValue({}),
   getAttestation: vi.fn().mockRejectedValue(new Error('not found')),
   getAttestationsForDid: vi.fn().mockResolvedValue([]),
+  listAttestations: vi.fn().mockResolvedValue([]),
+  verifyAttestation: vi.fn().mockResolvedValue({ valid: true, checks: { proofs: true }, reasons: [] }),
   getLatestAttestations: vi.fn().mockResolvedValue([]),
   getAttestationsByAttester: vi.fn().mockResolvedValue([]),
 }));
@@ -107,4 +111,77 @@ describe('attestation-queries', () => {
       expect(result).toEqual([]);
     });
   });
+
+  describe('getVerifiedAttestationsForDIDWithMetadata', () => {
+    beforeEach(() => {
+      vi.mocked(getContractAddress).mockReset();
+      vi.mocked(reputation.listAttestations).mockReset();
+      vi.mocked(reputation.verifyAttestation).mockReset();
+      vi.mocked(reputation.verifyAttestation).mockResolvedValue({
+        valid: true,
+        checks: { proofs: true },
+        reasons: [],
+      });
+    });
+
+    it('runs proof verification only for user review schemas', async () => {
+      vi.mocked(getContractAddress).mockReturnValue('0x' + '1'.repeat(40));
+      vi.spyOn(chains, 'getChainById').mockReturnValue({ id: 66238, rpc: 'https://rpc.testnet.chain.oma3.org/' } as any);
+
+      const userReviewSchema = {
+        id: 'user-review',
+        title: 'User Review',
+        deployedUIDs: { 66238: '0x' + 'a'.repeat(64) },
+      } as any;
+      const responseSchema = {
+        id: 'user-review-response',
+        title: 'User Review Response',
+        deployedUIDs: { 66238: '0x' + 'b'.repeat(64) },
+      } as any;
+      const certificationSchema = {
+        id: 'certification',
+        title: 'Certification',
+        deployedUIDs: { 66238: '0x' + 'c'.repeat(64) },
+      } as any;
+
+      const getAllSchemasSpy = vi.spyOn(schemas, 'getAllSchemas').mockReturnValue([
+        userReviewSchema,
+        responseSchema,
+        certificationSchema,
+      ]);
+
+      vi.mocked(reputation.listAttestations).mockResolvedValue([
+        sdkAttestation(userReviewSchema.deployedUIDs[66238]),
+        sdkAttestation(responseSchema.deployedUIDs[66238]),
+        sdkAttestation(certificationSchema.deployedUIDs[66238]),
+      ] as any);
+
+      const results = await getVerifiedAttestationsForDIDWithMetadata('did:web:example.com');
+
+      expect(reputation.verifyAttestation).toHaveBeenCalledTimes(2);
+      expect(results).toEqual([
+        expect.objectContaining({ schemaId: 'user-review', verification: expect.objectContaining({ valid: true }) }),
+        expect.objectContaining({ schemaId: 'user-review-response', verification: expect.objectContaining({ valid: true }) }),
+        expect.objectContaining({ schemaId: 'certification', verification: undefined }),
+      ]);
+
+      getAllSchemasSpy.mockRestore();
+    });
+  });
 });
+
+function sdkAttestation(schema: string) {
+  return {
+    uid: '0x' + '1'.repeat(64),
+    schema,
+    attester: '0x' + '2'.repeat(40),
+    recipient: '0x' + '3'.repeat(40),
+    data: {},
+    raw: '0x',
+    time: 1n,
+    expirationTime: 0n,
+    revocationTime: 0n,
+    refUID: '0x' + '0'.repeat(64),
+    revocable: true,
+  };
+}


### PR DESCRIPTION
- Add the /verify page
- Replace the Caip10Input component with a new DidPkhInput
- SubjectIdInput, subject-confirmation-dialog, and AddSigningKeyDialog now use DidPkhInput directly
- attestation-card: add "Verified" and "Trusted" badges, show controller witness details, hide verification section for user reviews
- attestation-detail-modal: add Status section with friendly check names
- latest-attestations: accept approvedIssuers prop for Trusted badge
- attestation-queries: add sortByCategoryPriority utility, remove getSubjectControllerAuthorization
- header: add Verify nav link, suppress hydration warning on nav

## Risk Level

**Risk:** medium

## Summary

Creates a new verify page and uses a new widget for blockchain DIDs

## Testing Performed

Manual on local and automated tests

## CI Status

- [ ] All required checks pass
