### PR TITLE
feat: UI terminology and layout refinements

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -246,7 +246,7 @@ function AccountSection({
                 {serviceDids.length > 1 ? "Service IDs" : "Service ID"}
               </div>
               <Button variant="outline" size="sm" onClick={onAddSubject}>
-                + Add Subject
+                + Add Service ID
               </Button>
             </div>
             <div className="mt-2 space-y-2">
@@ -266,10 +266,10 @@ function AccountSection({
               ) : (
                 <div className="space-y-2">
                   <p className="text-sm text-muted-foreground">
-                    No subject identifier configured.
+                    No service ID configured.
                   </p>
                   <p className="text-sm text-muted-foreground">
-                    You only need a subject if you represent a service, application, or smart contract that others will review or attest to.
+                    You only need a service ID if you represent a service, application, or smart contract that others will review or attest to.
                   </p>
                 </div>
               )}
@@ -1658,6 +1658,7 @@ function ServiceTrustWorkspace({
           </div>
         </section>
 
+        {/* Linked Identifiers — hidden for now, needs copy refinement
         <section className="space-y-3">
           <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
             <div>
@@ -1692,6 +1693,7 @@ function ServiceTrustWorkspace({
             </Link>
           </Button>
         </section>
+        */}
 
         {serviceCredentials.length > 0 ? (
           <section className="space-y-3">
@@ -1782,7 +1784,7 @@ function ServiceTrustWorkspace({
               <p className="text-sm text-muted-foreground">Third-party reviews filed against your service identities.</p>
             </div>
             <div className="flex shrink-0 items-center gap-2">
-              <Button variant="default" size="sm" asChild>
+              {/* <Button variant="default" size="sm" asChild>
                 <a href={`${buildServiceUrl("app.omatrust.org")}/widgets/reviews/create`} target="_blank" rel="noopener noreferrer">
                   Create review widget
                 </a>
@@ -1794,7 +1796,7 @@ function ServiceTrustWorkspace({
                 className="text-xs text-primary underline underline-offset-2 hover:text-primary/80"
               >
                 Docs
-              </a>
+              </a> */}
             </div>
           </div>
           {isLoadingServiceAttestations ? (
@@ -2114,7 +2116,7 @@ function DashboardContent() {
             <RefreshCw className={`h-4 w-4 mr-2 ${isLoading ? "animate-spin" : ""}`} />
             Refresh
           </Button>
-          <PublishButton />
+          {/* <PublishButton /> */}
         </div>
       </div>
 

--- a/src/app/verify/page.tsx
+++ b/src/app/verify/page.tsx
@@ -51,7 +51,7 @@ function getSubjectType(did: string) {
   if (did.startsWith("did:pkh:")) return "Blockchain Address"
   if (did.startsWith("did:jwk:")) return "JWK Key"
   if (did.startsWith("did:handle:")) return "Social Handle"
-  return "DID"
+  return "ID"
 }
 
 function StatusBadge({ ok, label }: { ok: boolean; label: string }) {
@@ -157,7 +157,7 @@ export default function VerifyPage() {
     const controller = controllerDid.trim()
 
     if (!subject) {
-      setError("Select a subject to verify.")
+      setError("Select a service ID to verify.")
       return
     }
 
@@ -232,8 +232,7 @@ export default function VerifyPage() {
           <ShieldCheck className="h-5 w-5" />
         </div>
         <div>
-          <p className="technical-label text-primary">Trust Verifier</p>
-          <h1 className="text-3xl font-semibold tracking-tight">Verify</h1>
+          <h1 className="text-3xl font-semibold tracking-tight">Trust Verifier</h1>
         </div>
       </div>
 
@@ -241,7 +240,7 @@ export default function VerifyPage() {
         <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
           <div>
             <div className="mb-2 flex items-center justify-between gap-3">
-              <label className="text-sm font-medium text-foreground">Subject</label>
+              <label className="text-sm font-medium text-foreground">Service ID</label>
               <Badge variant="secondary">Required</Badge>
             </div>
             <SubjectIdInput
@@ -286,8 +285,7 @@ export default function VerifyPage() {
             <section className="rounded-xl border border-border/70 bg-card/70 p-5 shadow-sm shadow-slate-950/5 sm:p-6">
               <div className="mb-5 flex flex-wrap items-center justify-between gap-3">
                 <div>
-                  <p className="technical-label text-primary">Controller Authorization</p>
-                  <h2 className="text-xl font-semibold tracking-tight">Authorization Result</h2>
+                  <p className="technical-label text-primary">Signing Key Authorization</p>
                 </div>
                 {result.keyAuthorization ? (
                   <StatusBadge
@@ -314,7 +312,7 @@ export default function VerifyPage() {
                         <span className="font-mono text-xs">{result.keyAuthorization.controllerDid}</span>
                       </p>
                       <p className="mt-2 text-sm font-medium text-foreground/70">
-                        Mechanisms: {result.keyAuthorization.sources.length > 0 ? result.keyAuthorization.sources.join(", ") : "None"}
+                        Verification Methods: {result.keyAuthorization.sources.length > 0 ? result.keyAuthorization.sources.join(", ") : "None"}
                       </p>
                     </div>
                     <div className="flex shrink-0 flex-wrap gap-2">
@@ -331,20 +329,15 @@ export default function VerifyPage() {
           <section className="rounded-xl border border-border/70 bg-card/70 p-5 shadow-sm shadow-slate-950/5 sm:p-6">
             <div className="mb-5 flex flex-wrap items-center justify-between gap-3">
               <div>
-                <p className="technical-label text-primary">Subject Summary</p>
-                <h2 className="text-xl font-semibold tracking-tight">Trust Profile</h2>
+                <p className="technical-label text-primary">Service Summary</p>
               </div>
               <Badge variant="secondary">{getSubjectType(result.subjectDid)}</Badge>
             </div>
 
             <div className="grid gap-4 lg:grid-cols-2">
               <div className="min-w-0 rounded-lg border border-border/70 bg-muted/30 p-4">
-                <p className="text-xs font-medium uppercase text-muted-foreground">Subject DID</p>
+                <p className="text-xs font-medium uppercase text-muted-foreground">Service ID</p>
                 <p className="mt-2 break-all font-mono text-sm">{result.subjectDid}</p>
-              </div>
-              <div className="min-w-0 rounded-lg border border-border/70 bg-muted/30 p-4">
-                <p className="text-xs font-medium uppercase text-muted-foreground">Canonical DID</p>
-                <p className="mt-2 break-all font-mono text-sm">{result.canonicalDid}</p>
               </div>
             </div>
 
@@ -359,15 +352,15 @@ export default function VerifyPage() {
           </section>
 
           <section>
-            <div className="mb-3">
-              <p className="technical-label text-primary">Attestations</p>
-            </div>
             <div className="rounded-xl border border-border/70 bg-card/70 px-4 py-2 shadow-sm shadow-slate-950/5 sm:px-8">
+              <div className="mb-3 pt-4">
+                <p className="technical-label text-primary">Attestations</p>
+              </div>
               <LatestAttestations
                 showHeading={false}
                 data={result.attestations}
                 approvedIssuers={result.approvedIssuers}
-                emptyMessage="No attestations found for this subject."
+                emptyMessage="No attestations found for this service."
               />
             </div>
           </section>

--- a/src/components/AttestationForm.tsx
+++ b/src/components/AttestationForm.tsx
@@ -376,7 +376,7 @@ export function AttestationForm({ schema, validateForm }: AttestationFormProps) 
         logger.log('[AttestationForm] Backend requires subject ownership proof, opening dialog')
         pendingSubmitDataRef.current = buildCompleteData()
         setSubjectDialogMessage(
-          'Subject ownership verification failed. Re-confirm your proof and try again.  Failure explanation- ' + (error.details || error.message)
+          'Service ID ownership verification failed. Re-confirm your proof and try again.  Failure explanation- ' + (error.details || error.message)
         )
         setSubjectDialogOpen(true)
         return

--- a/src/components/EvidencePointerProofInput.tsx
+++ b/src/components/EvidencePointerProofInput.tsx
@@ -157,7 +157,7 @@ export function EvidencePointerProofInput({
             <p className="text-xs">
               {controllerDid
                 ? "Enter the controller field above to generate the verification string."
-                : "Connect your wallet or enter the controller field to generate the verification string."}
+                : "Sign in or enter the controller field to generate the verification string."}
             </p>
           </div>
         )}

--- a/src/components/ProofInput.tsx
+++ b/src/components/ProofInput.tsx
@@ -46,7 +46,7 @@ const proofTypeDefs: Record<string, { emoji: string; label: string; description:
   "pop-eip712": {
     emoji: "✍️",
     label: "EIP-712 signature",
-    description: "Sign a typed message with your wallet to prove control"
+    description: "Sign a typed message using your account key to prove control"
   },
   "pop-jws": {
     emoji: "🔏",

--- a/src/components/auth-entry-dialog.tsx
+++ b/src/components/auth-entry-dialog.tsx
@@ -65,7 +65,7 @@ function getInitialStep(request: AuthDialogRequest): WizardStep {
 function getDialogTitle(step: WizardStep) {
   switch (step) {
     case "createSimple": return "Create Account"
-    case "setupSubject": return "Verify Subject Ownership"
+    case "setupSubject": return "Verify Service ID Ownership"
     case "authenticated": return "Signed In"
     case "signin":
     case "chooser":
@@ -79,21 +79,21 @@ function getFriendlyError(error: unknown) {
       case "BACKEND_UNREACHABLE":
         return "The OMATrust backend is not reachable right now."
       case "EXECUTION_MODE_REQUIRED":
-        return "Choose how this wallet should publish before we finish creating your account."
+        return "Choose how your account should publish before we finish setup."
       case "EXECUTION_MODE_ALREADY_SET":
-        return "This wallet already has an execution mode configured. Sign in with the same choice you used before."
+        return "This account already has a publishing mode configured. Sign in with the same choice you used before."
       case "SUBJECT_ALREADY_EXISTS":
-        return "This subject is already attached to your account."
+        return "This service ID is already attached to your account."
       case "SUBJECT_OWNED_BY_ANOTHER_ACCOUNT":
-        return "That subject is already associated with another OMATrust account."
+        return "That service ID is already associated with another OMATrust account."
       case "INVALID_CHALLENGE":
         return "Your sign-in request expired or became invalid. Please try again."
       case "CHALLENGE_EXPIRED":
         return "Your sign-in request expired. Please try again."
       case "ACCOUNT_NOT_FOUND":
-        return "No account found for this wallet. Please create an account first."
+        return "No account found. Please create an account first."
       case "ACCOUNT_ALREADY_EXISTS":
-        return "This wallet already has an account. Please sign in instead."
+        return "An account already exists for this user ID. Please sign in instead."
       default:
         return error.message
     }
@@ -218,12 +218,8 @@ export function AuthEntryDialog({ request, onOpenChange }: AuthEntryDialogProps)
     }
 
     // Non-submission — close the dialog explicitly, then navigate.
-    const defaultDestination =
-      intent?.kind === "signin" || request.mode === "signin"
-        ? "/dashboard"
-        : "/account"
     onOpenChange(false)
-    router.push(request.redirectTo ?? defaultDestination)
+    router.push(request.redirectTo ?? "/dashboard")
   }, [isSubmissionFlow, onOpenChange, request, router])
 
   const hydrateSessionAfterVerify = async () => {
@@ -275,7 +271,7 @@ export function AuthEntryDialog({ request, onOpenChange }: AuthEntryDialogProps)
       // The wallet object is returned directly — we can read the account from it.
       const account = wallet.getAccount()
       if (!account) {
-        throw new Error("Wallet connected but no account available.")
+        throw new Error("Signed in but no account available.")
       }
       return { account, wallet }
     } catch {
@@ -406,7 +402,7 @@ export function AuthEntryDialog({ request, onOpenChange }: AuthEntryDialogProps)
 
   const handleVerifyAndAttachSubject = async () => {
     if (!walletDid) {
-      setErrorMessage("Connect a wallet before verifying a subject.")
+      setErrorMessage("Sign in before verifying a service ID.")
       return
     }
 
@@ -416,7 +412,7 @@ export function AuthEntryDialog({ request, onOpenChange }: AuthEntryDialogProps)
     }
 
     if (derivedDidWeb.toLowerCase() === walletDid.toLowerCase()) {
-      setErrorMessage("Add a subject identifier that is different from your wallet DID.")
+      setErrorMessage("Add a service ID that is different from your User ID.")
       return
     }
 
@@ -468,7 +464,7 @@ export function AuthEntryDialog({ request, onOpenChange }: AuthEntryDialogProps)
       }
 
       if (!attachedSubject) {
-        throw new Error("The subject could not be attached to your account.")
+        throw new Error("The service ID could not be attached to your account.")
       }
 
       const refreshedSession = await refreshSession()
@@ -518,10 +514,10 @@ export function AuthEntryDialog({ request, onOpenChange }: AuthEntryDialogProps)
         <div className="rounded-xl border border-primary/20 bg-primary/5 px-4 py-3">
           <div className="flex items-center gap-2 text-sm font-medium text-foreground">
             <Loader2 className="h-4 w-4 animate-spin text-primary" />
-            {isAddingSubject ? "Adding your subject…" : "Verifying subject ownership…"}
+            {isAddingSubject ? "Adding your service ID…" : "Verifying service ID ownership…"}
           </div>
           <p className="mt-1.5 text-sm text-muted-foreground">
-            Keep this dialog open while we confirm control of your subject and attach it to your account.
+            Keep this dialog open while we confirm control of your service ID and attach it to your account.
           </p>
         </div>
       )
@@ -568,7 +564,7 @@ export function AuthEntryDialog({ request, onOpenChange }: AuthEntryDialogProps)
         <div className="rounded-xl border border-border/80 bg-card p-5 shadow-sm shadow-slate-950/5">
           <h3 className="text-lg font-semibold tracking-tight text-foreground">Existing account</h3>
           <p className="mt-2 text-sm text-muted-foreground">
-            Sign in to your existing account with your wallet, email, or social login.
+            Sign in to your existing with passkey, crypto wallet, email, or social login.
           </p>
           <div className="mt-4">
             <Button
@@ -602,7 +598,7 @@ export function AuthEntryDialog({ request, onOpenChange }: AuthEntryDialogProps)
       <div className="rounded-xl border border-border/80 bg-card p-5 shadow-sm shadow-slate-950/5">
         <h3 className="text-lg font-semibold tracking-tight text-foreground">Existing account</h3>
         <p className="mt-2 text-sm text-muted-foreground">
-          Sign in to your existing account with your wallet, email, or social login.
+          Sign in with your passkey, crypto wallet, email, or social login.
         </p>
         <div className="mt-4">
           <Button
@@ -635,6 +631,9 @@ export function AuthEntryDialog({ request, onOpenChange }: AuthEntryDialogProps)
         </div>
 
         <div className="space-y-3">
+          <p className="text-sm text-muted-foreground">
+            OMATrust accounts are based on keys. You can use a passkey, a wallet you already own, or email/social login (we&apos;ll create a key for you). Your User ID will be based on your login key.
+          </p>
           <div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center">
             <Button
               type="button"
@@ -680,13 +679,13 @@ export function AuthEntryDialog({ request, onOpenChange }: AuthEntryDialogProps)
     return (
       <div className="space-y-5">
         <div className="rounded-xl border border-border/80 bg-card p-4">
-          <p className="font-medium text-foreground">Add your Subject Identifier.</p>
+          <p className="font-medium text-foreground">Add your Service ID.</p>
           <p className="mt-2 text-sm text-muted-foreground">
-            This attestation needs a verified subject before it can be submitted. Add a URL you control for yourself or your organization.
+            This attestation needs a verified service ID before it can be submitted. Add a URL you control for yourself or your organization.
           </p>
           {derivedDidWeb ? (
             <p className="mt-3 break-all text-xs text-muted-foreground">
-              Subject: <span className="font-mono">{derivedDidWeb}</span>
+              Service ID: <span className="font-mono">{derivedDidWeb}</span>
             </p>
           ) : null}
         </div>
@@ -709,7 +708,7 @@ export function AuthEntryDialog({ request, onOpenChange }: AuthEntryDialogProps)
 
         <div className="space-y-3 rounded-xl border border-border/80 bg-muted/30 p-4 text-sm text-muted-foreground">
           <div className="space-y-2">
-            <p className="font-medium text-foreground">Verification method</p>
+            <p className="font-medium text-foreground">Verification method (DNS or did.json)</p>
             <div className="flex flex-wrap gap-2">
               <button
                 type="button"
@@ -780,7 +779,7 @@ export function AuthEntryDialog({ request, onOpenChange }: AuthEntryDialogProps)
             onClick={() => void handleVerifyAndAttachSubject()}
             disabled={!subjectReady || isVerifyingSubject || isAddingSubject}
           >
-            Verify and Add Subject
+            Verify and Add Service ID
           </Button>
         </div>
       </div>

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -23,8 +23,8 @@ const navLinks: NavLink[] = [
 ]
 
 const HINT_MESSAGES: Record<string, string> = {
-  "account-exists": "This wallet already has an account. Please sign in instead.",
-  "no-account": "No account found for this wallet. Please create an account first.",
+  "account-exists": "An account already exists for this user ID. Please sign in instead.",
+  "no-account": "No account found. Please create an account first.",
 }
 
 export function Header() {

--- a/src/components/pre-alpha-banner.tsx
+++ b/src/components/pre-alpha-banner.tsx
@@ -28,7 +28,7 @@ export function PreAlphaBanner() {
     <div className="relative border-b border-primary/30 bg-primary/10 px-4 py-3 text-foreground shadow-sm">
       <div className="max-w-7xl mx-auto flex items-center justify-between">
         <p className="text-sm font-medium">
-          Public Beta running on mainnet- your data will not be lost. If you encounter an issue, please{' '}
+          Public Beta running on OMAChain mainnet- your data will not be lost. If you encounter an issue, please{' '}
           <a
             href="https://github.com/oma3dao/rep-attestation-frontend/issues/new/choose"
             target="_blank"

--- a/src/components/subject-confirmation-dialog.tsx
+++ b/src/components/subject-confirmation-dialog.tsx
@@ -137,22 +137,22 @@ export function SubjectConfirmationDialog({
 
   async function handleVerify() {
     if (!walletDid) {
-      setErrorMessage("Connect your wallet before verifying a subject.")
+      setErrorMessage("Sign in before verifying a service ID.")
       return
     }
 
     if (!subjectDid) {
-      setErrorMessage("Enter a subject identifier before verifying.")
+      setErrorMessage("Enter a service ID before verifying.")
       return
     }
 
     if (subjectDid.toLowerCase() === walletDid.toLowerCase()) {
-      setErrorMessage("This matches your default wallet subject. Add a separate subject identifier instead.")
+      setErrorMessage("This matches your User ID. Add a separate service ID instead.")
       return
     }
 
     if (normalizedExistingDids.has(subjectDid.toLowerCase())) {
-      setErrorMessage("This subject is already attached to your account.")
+      setErrorMessage("This service ID is already attached to your account.")
       return
     }
 
@@ -199,7 +199,7 @@ export function SubjectConfirmationDialog({
             : error.details || error.message
         )
       } else {
-        setErrorMessage(error instanceof Error ? error.message : "Failed to verify subject ownership.")
+        setErrorMessage(error instanceof Error ? error.message : "Failed to verify service ID ownership.")
       }
     } finally {
       setIsVerifying(false)
@@ -208,12 +208,12 @@ export function SubjectConfirmationDialog({
 
   async function handleSubmit() {
     if (!subjectDid) {
-      setErrorMessage("Enter a subject identifier before submitting.")
+      setErrorMessage("Enter a service ID before submitting.")
       return
     }
 
     if (verificationState !== "verified") {
-      setErrorMessage("Verify ownership before adding this subject.")
+      setErrorMessage("Verify ownership before adding this service ID.")
       return
     }
 
@@ -236,7 +236,7 @@ export function SubjectConfirmationDialog({
         })
         setErrorMessage(error.details || error.message)
       } else {
-        setErrorMessage(error instanceof Error ? error.message : "Failed to add subject.")
+        setErrorMessage(error instanceof Error ? error.message : "Failed to add service ID.")
       }
     } finally {
       setIsSubmitting(false)
@@ -261,7 +261,7 @@ export function SubjectConfirmationDialog({
       return (
         <div className="space-y-3 rounded-xl border border-border/80 bg-muted/30 p-4 text-sm text-muted-foreground">
           <div className="space-y-2">
-            <p className="font-medium text-foreground">Verification method</p>
+            <p className="font-medium text-foreground">Verification method (DNS or did.json)</p>
             <div className="flex flex-wrap gap-2">
               <button
                 type="button"
@@ -311,7 +311,7 @@ export function SubjectConfirmationDialog({
       <div className="space-y-2 rounded-xl border border-border/80 bg-muted/30 p-4 text-sm text-muted-foreground">
         <p className="font-medium text-foreground">How verification works</p>
         <p>
-          The wallet you are signed in with must either match this subject DID directly or control the contract through a standard ownership pattern such as <span className="font-mono text-xs">owner()</span>, <span className="font-mono text-xs">admin()</span>, or <span className="font-mono text-xs">getOwner()</span>.
+          The wallet you are signed in with must either match this service ID directly or control the contract through a standard ownership pattern such as <span className="font-mono text-xs">owner()</span>, <span className="font-mono text-xs">admin()</span>, or <span className="font-mono text-xs">getOwner()</span>.
         </p>
       </div>
     )
@@ -321,18 +321,18 @@ export function SubjectConfirmationDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-2xl">
         <DialogHeader>
-          <DialogTitle>Verify Subject Ownership</DialogTitle>
+          <DialogTitle>Verify Service ID Ownership</DialogTitle>
           <DialogDescription>
-            Choose a DID method, confirm ownership, and then submit the subject to your account.
+            Choose an ID format, confirm ownership, and then add the service ID to your account.
           </DialogDescription>
         </DialogHeader>
 
         <div className="space-y-5">
           <div className="space-y-2">
-            <Label htmlFor="subject-did-method">DID method</Label>
+            <Label htmlFor="subject-did-method">ID format</Label>
             <Select value={selectedMethod} onValueChange={(value) => handleDidMethodChange(value as SupportedDidMethod)}>
               <SelectTrigger id="subject-did-method">
-                <SelectValue placeholder="Select a DID method" />
+                <SelectValue placeholder="Select an ID format" />
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="did:web">did:web</SelectItem>
@@ -374,7 +374,7 @@ export function SubjectConfirmationDialog({
               onClick={handleSubmit}
               disabled={isSubmitting || verificationState !== "verified"}
             >
-              {isSubmitting ? "Adding Subject…" : "Submit"}
+              {isSubmitting ? "Adding Service ID…" : "Submit"}
             </Button>
           </div>
         </div>

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -103,7 +103,7 @@ const certificationFields: FormField[] = [
   {
     "name": "subjectURI",
     "type": "uri",
-    "label": "Subject Informational URI",
+    "label": "Service Informational URI",
     "description": "Optional URI that provides mutable, human-readable metadata about the certification recipient.",
     "required": false,
     "placeholder": "https://example.com",
@@ -373,7 +373,7 @@ const keyBindingFields: FormField[] = [
     "name": "proofs",
     "type": "array",
     "label": "Proofs",
-    "description": "One or more proofs that demonstrate the service's authorization of the key. Optional when verifiers can confirm authorization through other means (e.g., DNS TXT, did.json, or controller witness for did:web/did:pkh subjects).",
+    "description": "One or more proofs that demonstrate the service's authorization of the key. Optional when verifiers can confirm authorization through other means (e.g., DNS TXT, did.json, or controller witness for did:web/did:pkh IDs).",
     "required": false,
     "placeholder": "Enter proofs",
     "proofPurpose": "shared-control",
@@ -473,7 +473,7 @@ const linkedIdentifierFields: FormField[] = [
     "name": "proofs",
     "type": "array",
     "label": "Proofs",
-    "description": "One or more proofs that demonstrate the two linked IDs have the same ownership. Optional when verifiers can confirm the link through other means (e.g., controller witness for did:web/did:pkh subjects).",
+    "description": "One or more proofs that demonstrate the two linked IDs have the same ownership. Optional when verifiers can confirm the link through other means (e.g., controller witness for did:web/did:pkh IDs).",
     "required": false,
     "placeholder": "Enter proofs",
     "proofPurpose": "shared-control",
@@ -566,7 +566,7 @@ const securityAssessmentFields: FormField[] = [
     "name": "versionHW",
     "type": "string",
     "label": "Hardware Version",
-    "description": "Hardware version of the assessed subject, if applicable.",
+    "description": "Hardware version of the assessed service, if applicable.",
     "required": false,
     "placeholder": "Enter hardware version",
     "maxLength": 50
@@ -814,7 +814,7 @@ const userReviewFields: FormField[] = [
 export const certificationSchema: AttestationSchema = {
   id: 'certification',
   title: 'Certification',
-  description: 'Certification bodies use this attestation when a subject passes certification.',
+  description: 'Certification bodies use this attestation when a service passes certification.',
   fields: certificationFields,
   easSchemaString: 'string subject, string organization, string version, string versionHW, string subjectURI, string programID, string programURI, string assessor, string assessorURI, string certificationLevel, string outcome, string reportURI, string reportDigest, string payload, string payloadVersion, string payloadSpecURI, string payloadSpecDigest, uint256 issuedAt, uint256 effectiveAt, uint256 expiresAt',
   deployedUIDs: {
@@ -876,7 +876,7 @@ export const controllerWitnessSchema: AttestationSchema = {
 export const keyBindingSchema: AttestationSchema = {
   id: 'key-binding',
   title: 'Key Binding',
-  description: 'Publishes a cryptographic key associated with a DID. Supports multi-purpose bindings, rotation, and revocation. Each attestation binds one key to one subject.',
+  description: 'Publishes a cryptographic key associated with an ID. Supports multi-purpose bindings, rotation, and revocation. Each attestation binds one key to one service.',
   fields: keyBindingFields,
   revocable: true,
   easSchemaString: 'string subject, string keyId, string publicKeyJwk, string[] keyPurpose, string[] proofs, uint256 issuedAt, uint256 effectiveAt, uint256 expiresAt',
@@ -900,7 +900,7 @@ export const keyBindingSchema: AttestationSchema = {
 export const linkedIdentifierSchema: AttestationSchema = {
   id: 'linked-identifier',
   title: 'Linked Identifier',
-  description: 'An attestation where the attester (a trusted third party) asserts that the subject controls the linked identifier. Both subject and linkedId MUST be valid DIDs, creating a symmetric DID-to-DID link that attests two identities are owned by the same entity.',
+  description: 'An attestation where the attester (a trusted third party) asserts that the service controls the linked identifier. Both subject and linkedId MUST be valid IDs, creating a symmetric ID-to-ID link that attests two identities are owned by the same entity.',
   fields: linkedIdentifierFields,
   revocable: true,
   easSchemaString: 'string subject, string linkedId, string[] proofs, uint256 issuedAt, uint256 effectiveAt, uint256 expiresAt',

--- a/tests/app/dashboard/page.test.tsx
+++ b/tests/app/dashboard/page.test.tsx
@@ -713,7 +713,6 @@ describe('Dashboard Page', () => {
       expect(screen.getByText('Service Management')).toBeInTheDocument()
     })
     expect(screen.getByText('External Key Authorizations')).toBeInTheDocument()
-    expect(screen.getByText('Linked Identifiers')).toBeInTheDocument()
   })
 
   it('does not render the ServiceTrustWorkspace without a service subject', async () => {

--- a/tests/app/verify/page.test.tsx
+++ b/tests/app/verify/page.test.tsx
@@ -112,7 +112,7 @@ describe('Verify page', () => {
     })
 
     expect(mockGetControllerConfirmation).not.toHaveBeenCalled()
-    expect(screen.getByText('Trust Profile')).toBeInTheDocument()
+    expect(screen.getByText('Service Summary')).toBeInTheDocument()
     expect(screen.getByText('1 attestations')).toBeInTheDocument()
     expect(screen.getByText('Certifications')).toBeInTheDocument()
   })
@@ -134,7 +134,6 @@ describe('Verify page', () => {
       })
     })
 
-    expect(screen.getByText('Authorization Result')).toBeInTheDocument()
     expect(screen.getByText('Authorized')).toBeInTheDocument()
     expect(screen.getByText(/Basic:/)).toBeInTheDocument()
     expect(screen.getByText(/Intermediate:/)).toBeInTheDocument()

--- a/tests/components/EvidencePointerProofInput.test.tsx
+++ b/tests/components/EvidencePointerProofInput.test.tsx
@@ -255,7 +255,7 @@ describe('EvidencePointerProofInput', () => {
         />
       )
       expect(
-        screen.getByText(/Connect your wallet or enter the controller field/i)
+        screen.getByText(/Sign in or enter the controller field/i)
       ).toBeInTheDocument()
 
       // Restore the default mock

--- a/tests/components/pre-alpha-banner.test.tsx
+++ b/tests/components/pre-alpha-banner.test.tsx
@@ -30,7 +30,7 @@ describe('PreAlphaBanner', () => {
     render(<PreAlphaBanner />);
     
     expect(screen.getByText(/Public Beta/i)).toBeInTheDocument();
-    expect(screen.getByText(/Running on mainnet/i)).toBeInTheDocument();
+    expect(screen.getByText(/running on OMAChain mainnet/i)).toBeInTheDocument();
   });
 
   it('does not render on testnet', () => {

--- a/tests/components/subject-confirmation-dialog.test.tsx
+++ b/tests/components/subject-confirmation-dialog.test.tsx
@@ -69,7 +69,7 @@ describe('SubjectConfirmationDialog', () => {
 
   it('renders the dialog title and a disabled Verify button initially', () => {
     setup();
-    expect(screen.getByText('Verify Subject Ownership')).toBeInTheDocument();
+    expect(screen.getByText('Verify Service ID Ownership')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Verify' })).toBeDisabled();
     expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled();
   });


### PR DESCRIPTION
- Redirect new signups to dashboard instead of account page
- Rename "subject" to "service ID" in all user-facing strings
- Rename "DID" to "ID" and "DID method" to "ID format"
- Replace "wallet" with sign-in language in auth error messages
- Add account creation explainer about keys/passkeys/wallets
- Use "User ID" instead of "wallet ID" for some identity references
- Remove Canonical ID box from verify page (was duplicate of Service ID)
- Move Attestations header inside its card on verify page
- Comment out Publish button, review widget, and linked identifiers section temporarily
- Refine headings and fix typos
- Update schema.ts to reflect above UI changes
- Update tests to match new copy and removed elements

## Risk Level

**Risk:** low (UI refinements and pre-launch)

## Summary

Make the UI more user-friendly

## Testing Performed

Manual localhost, automated

## CI Status

- [ ] All required checks pass

## Self-Merge

- [ ] This is a self-merge
- **Reason for emergency self-merge:**

Merging into staging so lower risk. Needed for production launch.
