### PR TITLE
Feat/Add Responsibility Claims

### DIFF
--- a/docs/features/artifact/plan.md
+++ b/docs/features/artifact/plan.md
@@ -1,0 +1,249 @@
+# Artifact Verification --- Implementation Plan
+
+**Reference:** [spec.md](./spec.md)
+
+---
+
+## Phase 1: Library Implementation + Frontend Integration
+
+Implement the three SDK functions as a local library in the frontend, integrate
+them into the verify page and dashboard, then validate with smoke tests.
+
+The library lives at `src/lib/artifact-verification.ts` during this phase. It
+imports from `@oma3/omatrust/reputation` and `@oma3/omatrust/identity` for
+primitives (listAttestations, getControllerAuthorization, parseArtifactDid,
+artifactDidFromBytes) and builds the higher-level verification logic on top.
+
+### Tasks
+
+#### 1.1 Implement `verifyResponsibilityClaim()`
+
+**File:** `src/lib/artifact-verification.ts`
+
+Implement the single-claim verifier per the spec. Internally:
+- Decode attestation data using `decodeAttestationData()` with the Responsibility
+  Claim schema string from `schemas.ts`.
+- Run the 6-check verification pipeline (schema, subject match, revocation,
+  effective dates, controller authorized, issued in window).
+- Return `VerifyResponsibilityClaimResult`.
+
+#### 1.2 Implement `getVerifiedArtifactAttestations()`
+
+**File:** `src/lib/artifact-verification.ts`
+
+High-level orchestrator:
+- Validate the `did:artifact` input via `parseArtifactDid()`.
+- Query attestations using existing `getVerifiedAttestationsForDIDWithMetadata()`
+  (which wraps `listAttestations`).
+- Group by schema ID.
+- Run `verifyResponsibilityClaim()` for each responsibility-claim attestation.
+- Return the grouped `GetVerifiedArtifactAttestationsResult`.
+
+#### 1.3 Implement `isArtifactClaimedBy()`
+
+**File:** `src/lib/artifact-verification.ts`
+
+Convenience wrapper:
+- Call `getVerifiedArtifactAttestations()`.
+- Filter `responsibilityClaims` where `responsibleParty` matches the input.
+- Optionally filter by `responsibilityTypes`.
+- Return `IsArtifactClaimedByResult`.
+
+#### 1.4 Add `artifact` subject type to `SubjectIdInput`
+
+Add "Artifact" to the allowed methods. Dual input: paste DID or file upload.
+
+#### 1.5 Integrate into Verify Page
+
+- Wire `getVerifiedArtifactAttestations()` when subject starts with `did:artifact:`.
+- Render artifact-specific results layout per spec (Security Assessments summary
+  at top, then Responsibility Claims, Certifications, Other).
+- Hide the optional controller/signing key input for artifact subjects.
+
+#### 1.6 Unhide Dashboard Publish Button
+
+- Unhide the existing Publish button on the dashboard.
+- Link to the attestation form with Responsibility Claim schema pre-selected.
+- Pre-fill `responsibleParty` with connected wallet DID if available.
+
+#### 1.7 Verify Creation Form
+
+- Confirm the attestation creation form renders correctly for Responsibility Claim.
+- Test delegated attestation submission on OMAChain Testnet.
+
+#### 1.8 Update schema priority ordering
+
+Add `responsibility-claim` to `SCHEMA_PRIORITY` in `attestation-queries.ts`.
+
+---
+
+### Phase 1 Smoke Tests
+
+Run these manually against OMAChain Testnet after implementation.
+
+| # | Test | Steps | Expected |
+|---|------|-------|----------|
+| S1 | Create Responsibility Claim | Use the attestation form to create a Responsibility Claim for a `did:artifact` with type "creator". Submit via delegated attestation. | Attestation created on-chain. Appears in dashboard attestation lists. |
+| S2 | Verify artifact with valid claim | Go to `/verify`, enter the `did:artifact` from S1. | Security Assessments summary at top (empty/zero). Responsibility Claim appears below with "Verified" badge. All 6 checks pass. |
+| S3 | Verify artifact via file upload | Go to `/verify`, select "Artifact", upload the original file. | DID is computed client-side. Same results as S2. |
+| S4 | Verify artifact with no attestations | Go to `/verify`, enter a random `did:artifact:b...` that has no attestations. | Empty state message displayed. |
+| S5 | Verify with revoked claim | Revoke the attestation from S1 via `eas-revoke` task. Re-verify the artifact. | Claim appears with failed verification — `notRevoked` check fails. |
+| S6 | Verify unauthorized attester | Create a claim from a wallet that is NOT authorized for the responsible party. | Claim appears with "Not authorized" — `controllerAuthorized` check fails. |
+| S7 | Malformed DID input | Enter `did:artifact:invalid` in the verify page. | Inline validation error, no query executed. |
+| S8 | Publish button | Click Publish on the dashboard. | Navigates to attestation form with Responsibility Claim schema pre-selected. Subject field is empty (user fills in artifact DID). |
+
+---
+
+## Phase 2: SDK Extraction + Full Test Coverage
+
+Move the verified library into the SDK, publish a new version, update the frontend
+to consume it, and write comprehensive tests.
+
+### Tasks
+
+#### 2.1 Move verification logic to SDK
+
+**Source:** `rep-attestation-frontend/src/lib/artifact-verification.ts`
+**Destination:** `omatrust-sdk/src/reputation/artifact-verification.ts`
+
+- Copy types and implementation.
+- Replace frontend-specific imports (`@/config/schemas`, `@/lib/attestation-queries`)
+  with SDK-internal equivalents (`./encode`, `./query`, `./types`).
+- The SDK version accepts a raw `AttestationQueryResult` (not `EnrichedAttestationResult`).
+  Enrichment remains the frontend's responsibility.
+
+#### 2.2 Export from SDK package
+
+**File:** `omatrust-sdk/src/reputation/index.ts`
+
+Add exports:
+```typescript
+export { verifyResponsibilityClaim } from "./artifact-verification";
+export { getVerifiedArtifactAttestations } from "./artifact-verification";
+export { isArtifactClaimedBy } from "./artifact-verification";
+```
+
+Export types from `./types.ts`:
+```typescript
+export type {
+  VerifyResponsibilityClaimParams,
+  VerifyResponsibilityClaimResult,
+  GetVerifiedArtifactAttestationsParams,
+  GetVerifiedArtifactAttestationsResult,
+  IsArtifactClaimedByParams,
+  IsArtifactClaimedByResult,
+  VerifiedResponsibilityClaim,
+  VerifiedArtifactAttestation,
+};
+```
+
+#### 2.3 Write SDK tests
+
+Create `omatrust-sdk/test/artifact-verification.test.ts` with full coverage.
+See test guidance below.
+
+#### 2.4 Publish SDK
+
+- Bump version in `package.json`.
+- Run full test suite.
+- Publish to npm (`@oma3/omatrust`).
+
+#### 2.5 Update frontend to use SDK
+
+**File:** `rep-attestation-frontend/src/lib/artifact-verification.ts`
+
+Replace the local implementation with imports from the SDK:
+
+```typescript
+export {
+  verifyResponsibilityClaim,
+  getVerifiedArtifactAttestations,
+  isArtifactClaimedBy,
+} from '@oma3/omatrust/reputation';
+```
+
+The frontend still wraps these with enrichment (schema metadata, decoded data)
+but the core verification logic now comes from the SDK.
+
+#### 2.6 Update `package.json`
+
+Bump the `@oma3/omatrust` dependency to the new version.
+
+#### 2.7 Regression test
+
+Re-run all Phase 1 smoke tests against the SDK-backed implementation to confirm
+no behavioral changes.
+
+---
+
+### Phase 2 Test Engineering Guidance
+
+These are the areas that need comprehensive automated test coverage (unit + integration).
+The test engineer should use the spec's type definitions and verification steps as the
+source of truth.
+
+#### `verifyResponsibilityClaim()` — Unit Tests
+
+**Happy path:**
+- Valid claim with authorized attester → all checks pass, `valid: true`.
+- Valid claim with multiple responsibility types → types correctly extracted.
+- Valid claim with `subjectLabel` → label present in result.
+- Valid claim near authorization window boundaries (issuedAt == anchoredFrom, issuedAt == until - 1).
+
+**Check isolation (each check fails independently):**
+- Missing `responsibleParty` → `schemaValid: false`.
+- Missing `subject` → `schemaValid: false`.
+- Missing `responsibilityType` → `schemaValid: false`.
+- Empty `responsibilityType` array → `schemaValid: false`.
+- Missing `issuedAt` → `schemaValid: false`.
+- Subject doesn't match provided `artifactDid` → `subjectMatches: false`.
+- `revocationTime > 0` → `notRevoked: false`.
+- `effectiveAt` in the future → `currentlyEffective: false`.
+- `expiresAt` in the past → `currentlyEffective: false`.
+- `expiresAt === 0` (no expiration) → `currentlyEffective: true`.
+- Controller not authorized → `controllerAuthorized: false`.
+- `issuedAt` before `anchoredFrom` → `issuedDuringAuthorizationWindow: false`.
+- `issuedAt` after `until` → `issuedDuringAuthorizationWindow: false`.
+
+**Edge cases:**
+- `artifactDid` param omitted → `subjectMatches` always true (no cross-check).
+- Case-insensitive subject matching (DID with mixed case).
+- Attestation with `effectiveAt === 0` → treated as "effective immediately".
+- Multiple checks fail simultaneously → all failures reported in `reasons[]`.
+
+#### `getVerifiedArtifactAttestations()` — Unit Tests
+
+- Empty result set (no attestations) → all arrays empty.
+- Mixed attestation types → correctly grouped by schema.
+- Responsibility claims verified, other schemas get standard verification.
+- Invalid `did:artifact` input → throws/rejects with descriptive error.
+- Valid DID with only non-responsibility-claim attestations → `responsibilityClaims` empty, others populated.
+
+#### `isArtifactClaimedBy()` — Unit Tests
+
+- Responsible party has valid claim → `claimed: true`.
+- Responsible party has no claims → `claimed: false`, reasons explain.
+- Filter by `responsibilityTypes` → only matching types returned.
+- Multiple claims from same party → all returned.
+- Claim exists but verification fails → `claimed: false`.
+
+#### Integration Tests (SDK)
+
+- SDK functions work without frontend-specific context (no Next.js, no `schemas.ts`).
+- Integration test: SDK functions called with a real provider against a Hardhat
+  local node with EAS deployed and test attestations created in a fixture.
+- Confirm `getVerifiedArtifactAttestations` correctly calls through to
+  `getControllerAuthorization` and respects its results.
+
+#### Frontend Regression Tests
+
+- `SubjectIdInput` accepts `did:artifact:b...` strings when `artifact` method is allowed.
+- `SubjectIdInput` file upload computes DID and populates input.
+- `SubjectIdInput` rejects malformed artifact DIDs.
+- Verify page hides controller input when subject is `did:artifact`.
+- Verify page shows controller input when subject is `did:web`.
+- Responsibility Claim card renders all expected fields.
+- Schema priority ordering: security assessments first, then responsibility claims.
+- Dashboard Publish button visible and navigates to correct form.
+- Frontend enrichment layer (decoding, schema title, trusted badge) still works
+  when verification is delegated to the SDK.

--- a/docs/features/artifact/spec.md
+++ b/docs/features/artifact/spec.md
@@ -1,0 +1,290 @@
+# Artifact Verification --- Specification
+
+**Status: Draft**
+
+## Purpose
+
+Add `did:artifact` verification to the OMATrust Portal. Users can input a
+`did:artifact` identifier (or upload a file to compute one) and see all verified
+Responsibility Claims, Security Assessments, Certifications, and other
+attestations associated with that content-addressed artifact.
+
+This feature implements
+[omatrust-sdk#34](https://github.com/oma3dao/omatrust-sdk/issues/34).
+
+## Background
+
+A `did:artifact` names an immutable byte sequence by its SHA-256 content hash
+(CIDv1, raw multicodec, base32-lower). Responsibility Claims allow an
+authorized identity to publicly accept responsibilities (creator, distributor,
+maintainer) for a subject, where the subject can be a `did:artifact`.
+
+The SDK provides:
+- `artifactDidFromBytes()` / `artifactDidFromJson()` — construct a did:artifact
+- `parseArtifactDid()` — validate and extract components
+- `verifyDidArtifact()` — verify content matches a did:artifact
+- `listAttestations()` / `getAttestationsForDid()` — query EAS attestations
+- `verifyAttestation()` — structural + lifecycle verification
+- `getControllerAuthorization()` — controller authorization window
+
+After this feature is complete, the SDK will additionally export:
+- `verifyResponsibilityClaim()` — schema-aware Responsibility Claim verification
+- `getVerifiedArtifactAttestations()` — high-level artifact verification entry point
+- `isArtifactClaimedBy()` — convenience check for a specific responsible party
+
+## Scope
+
+### In Scope
+
+- SDK functions for Responsibility Claim verification
+- Verify page integration: accept `did:artifact` as a subject type (paste or file upload)
+- Dashboard: unhide Publish button, link to Responsibility Claim attestation form
+- Responsibility Claim creation form (new schema in the attestation form picker)
+
+### Out of Scope
+
+- Responsibility Claims for non-artifact subjects (future — APIs, websites, agents)
+- Mainnet deployment of the schema (separate ops task)
+- Dedicated "Artifact Claims" dashboard section (future — deferred to avoid crowding)
+
+---
+
+## SDK Functions
+
+### `verifyResponsibilityClaim()`
+
+Verifies a single Responsibility Claim attestation.
+
+```typescript
+type VerifyResponsibilityClaimParams = {
+  attestation: AttestationQueryResult;
+  artifactDid?: string;           // Expected subject (optional cross-check)
+  provider: unknown;
+  easContractAddress?: Hex;
+  chain?: string;                 // CAIP-2 chain identifier
+};
+
+type VerifyResponsibilityClaimResult = {
+  valid: boolean;
+  responsibleParty: string;       // DID
+  controllerDid: string;          // DID of the attester-as-controller
+  responsibilityTypes: string[];  // e.g. ["creator", "maintainer"]
+  subjectLabel?: string;
+  authorization: ControllerAuthorizationResult;
+  checks: {
+    schemaValid: boolean;
+    subjectMatches: boolean;
+    notRevoked: boolean;
+    currentlyEffective: boolean;
+    controllerAuthorized: boolean;
+    issuedDuringAuthorizationWindow: boolean;
+  };
+  reasons: string[];              // Human-readable failure reasons
+};
+```
+
+**Verification steps:**
+
+1. Decode attestation data using the Responsibility Claim EAS schema string.
+2. Validate required fields: `responsibleParty`, `subject`, `responsibilityType`, `issuedAt`.
+3. If `artifactDid` supplied, confirm `subject` matches (case-insensitive).
+4. Check `revocationTime === 0` (not revoked via EAS).
+5. Check `effectiveAt <= now` and (`expiresAt === 0 || expiresAt > now`).
+6. Derive the controller DID from the attester address (`did:pkh:eip155:<chainId>:<attester>`).
+7. Call `getControllerAuthorization({ subjectDid: responsibleParty, controllerDid, chain })`.
+8. Confirm `authorization.authorized === true`.
+9. Confirm `issuedAt` falls within `[authorization.anchoredFrom, authorization.until ?? ∞)`.
+
+### `getVerifiedArtifactAttestations()`
+
+High-level entry point: queries and verifies all attestations for an artifact.
+
+```typescript
+type GetVerifiedArtifactAttestationsParams = {
+  artifactDid: string;
+  provider: unknown;
+  easContractAddress?: Hex;
+  chain?: string;
+  schemas?: Hex[];                // Override schema filter
+  fromBlock?: number;
+  limit?: number;
+};
+
+type VerifiedArtifactAttestation = {
+  attestation: EnrichedAttestationResult;
+  verification?: VerifyAttestationResult;
+};
+
+type VerifiedResponsibilityClaim = {
+  attestation: EnrichedAttestationResult;
+  verification: VerifyResponsibilityClaimResult;
+};
+
+type GetVerifiedArtifactAttestationsResult = {
+  artifactDid: string;
+  responsibilityClaims: VerifiedResponsibilityClaim[];
+  securityAssessments: VerifiedArtifactAttestation[];
+  certifications: VerifiedArtifactAttestation[];
+  otherAttestations: VerifiedArtifactAttestation[];
+};
+```
+
+**Behavior:**
+
+1. Parse and validate the `did:artifact` input (reject malformed DIDs early).
+2. Query all attestations where the subject is the artifact DID.
+3. Group by schema: responsibility-claim, security-assessment, certification, other.
+4. For Responsibility Claims: run `verifyResponsibilityClaim()` on each.
+5. For other schemas: run standard `verifyAttestation()`.
+6. Return grouped, verified results.
+
+### `isArtifactClaimedBy()`
+
+Convenience helper: does a specific responsible party claim this artifact?
+
+```typescript
+type IsArtifactClaimedByParams = {
+  artifactDid: string;
+  responsibleParty: string;       // DID to check
+  provider: unknown;
+  easContractAddress?: Hex;
+  chain?: string;
+  responsibilityTypes?: string[]; // Filter to specific types
+};
+
+type IsArtifactClaimedByResult = {
+  claimed: boolean;
+  claims: VerifiedResponsibilityClaim[];
+  matchedResponsibilityTypes: string[];
+  reasons: string[];
+};
+```
+
+---
+
+## UI Changes
+
+### Verify Page (`/verify`)
+
+**Subject input — Artifact mode:**
+
+The artifact input works like the blockchain address input for `did:pkh`:
+the user can either paste a `did:artifact:b...` string directly, or they can
+upload a file and the frontend computes the `did:artifact` from the file bytes
+using `artifactDidFromBytes()`.
+
+- Add `did:artifact` as a subject type option in the `SubjectIdInput` component.
+- When "Artifact" is selected, show two input modes:
+  - **Paste DID** — text input accepting `did:artifact:b...`
+  - **Upload file** — file picker that hashes the file client-side and derives the DID
+- Allowed methods for the verify page: `["web", "pkh", "jwk", "artifact"]`.
+
+**Results rendering — Artifact layout:**
+
+When the subject is a `did:artifact`, display results in this order:
+
+1. **Security Assessments Summary** (top — compact summary badges/counts,
+   minimal vertical space)
+2. **Responsibility Claims** section:
+   - Each claim card shows: responsible party DID, responsibility types (badges),
+     subject label (if provided), authorization status, verification checks.
+   - Green "Verified" badge when all checks pass.
+   - Expandable detail showing each check with pass/fail indicators.
+3. **Certifications** section (existing card format)
+4. **Other Attestations** section (existing card format)
+
+**No controller input for artifacts:**
+- The optional "Signing Key" controller input is hidden when subject type is `did:artifact`.
+  Authorization is evaluated per-claim (each claim has its own responsible party / controller).
+
+### Dashboard — Publish Button
+
+The existing hidden Publish button on the dashboard is unhidden and links to the
+attestation creation form pre-configured for the Responsibility Claim schema.
+
+The Publish button does NOT know the artifact DID — the user fills that in on the
+form. The button pre-selects the schema (Responsibility Claim) and optionally
+pre-fills the `responsibleParty` with the connected wallet's DID (if the user has
+one registered). The subject/artifact DID is entered by the user in the form.
+
+### Dashboard — Attestation Lists
+
+- Responsibility Claim attestations appear in "My Attestations" and "Latest Attestations"
+  using the existing attestation card format.
+- Schema title: "Responsibility Claim"
+- Decoded fields displayed: responsibleParty, subject, subjectLabel, responsibilityType
+
+### Attestation Creation Form
+
+- Responsibility Claim is available in the schema picker (already handled by
+  `update-schemas` since the schema is now in `schemas.ts`).
+- The form renders fields from the schema definition: responsibleParty, subject,
+  subjectLabel, responsibilityType, effectiveAt, expiresAt.
+- Subject field: SubjectIdInput with allowed methods `["web", "pkh", "jwk", "artifact"]`.
+- ResponsibleParty field: DID input with allowed methods `["web", "pkh", "handle"]`.
+- ResponsibilityType field: multi-select from the `x-oma3-enum` values (creator, distributor, maintainer).
+
+---
+
+## Schema Priority
+
+Add `responsibility-claim` to the category priority ordering:
+
+```typescript
+const SCHEMA_PRIORITY: Record<string, number> = {
+  'security-assessment': 0,
+  'responsibility-claim': 1,
+  'certification': 2,
+  'controller-witness': 3,
+  'key-binding': 4,
+  'linked-identifier': 5,
+  'user-review-response': 6,
+  'user-review': 7,
+}
+```
+
+---
+
+## Error Handling
+
+| Condition | Behavior |
+|-----------|----------|
+| Malformed `did:artifact` | Reject at input validation with inline error |
+| File upload too large | Reject with size limit message (TBD — 100MB?) |
+| No attestations found | Show empty state: "No attestations found for this artifact." |
+| Controller authorization fails | Claim shown with "Not authorized" badge + reason |
+| EAS query fails (RPC error) | Surface error in UI, allow retry |
+| Schema decode fails | Attestation shown as "raw" without decoded fields |
+
+---
+
+## Dependencies
+
+| Dependency | Status |
+|------------|--------|
+| `responsibility-claim.schema.json` authored | ✅ Done |
+| EAS schema generated (`Responsibility-Claim.eas.json`) | ✅ Done |
+| Schema deployed to OMAChain Testnet | ✅ Done (UID: `0x8779...b651`) |
+| Frontend `schemas.ts` updated | ✅ Done |
+| Backend trust anchors updated | ✅ Done (testnet) |
+| `did:artifact` support in SDK | ✅ Done (`@oma3/omatrust/identity`) |
+| `getControllerAuthorization()` in SDK | ✅ Done |
+| `listAttestations()` in SDK | ✅ Done |
+
+---
+
+## Acceptance Criteria
+
+- [ ] `verifyResponsibilityClaim()` validates all 6 checks and returns structured results.
+- [ ] `getVerifiedArtifactAttestations()` queries and groups attestations by schema type.
+- [ ] `isArtifactClaimedBy()` correctly reports whether a party claims an artifact.
+- [ ] Verify page accepts `did:artifact` via paste or file upload.
+- [ ] File upload computes `did:artifact` client-side and queries attestations.
+- [ ] Verify page renders Security Assessments summary at top, then Responsibility Claims.
+- [ ] Controller input is hidden when subject is `did:artifact`.
+- [ ] Dashboard Publish button visible, links to Responsibility Claim form.
+- [ ] Responsibility Claim creation form works and submits via delegated attestation.
+- [ ] Responsibility Claims appear in dashboard attestation lists.
+- [ ] Schema priority ordering: security assessments first, then responsibility claims.
+- [ ] Error states handled gracefully (malformed DID, no attestations, RPC failure, file too large).
+- [ ] Unit tests cover the SDK verification functions with full coverage.

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -2086,7 +2086,7 @@ function DashboardContent() {
             <RefreshCw className={`h-4 w-4 mr-2 ${isLoading ? "animate-spin" : ""}`} />
             Refresh
           </Button>
-          {/* <PublishButton /> */}
+          <PublishButton subjects={registeredSubjects} />
         </div>
       </div>
 

--- a/src/app/verify/page.tsx
+++ b/src/app/verify/page.tsx
@@ -246,11 +246,12 @@ export default function VerifyPage() {
             <SubjectIdInput
               value={subjectDid}
               onChange={(did) => setSubjectDid(did ?? "")}
-              allowedMethods={["web", "pkh", "jwk"]}
+              allowedMethods={["web", "pkh", "jwk", "artifact"]}
               className="ml-0"
             />
           </div>
 
+          {!subjectDid.startsWith("did:artifact:") && (
           <div>
             <div className="mb-2 flex items-center justify-between gap-3">
               <label className="text-sm font-medium text-foreground">Signing Key</label>
@@ -263,6 +264,7 @@ export default function VerifyPage() {
               className="ml-0"
             />
           </div>
+          )}
         </div>
 
         {error ? (

--- a/src/components/SubjectIdInput.tsx
+++ b/src/components/SubjectIdInput.tsx
@@ -69,7 +69,7 @@ export function SubjectIdInput({
     pkh:      { value: "did:pkh", emoji: "🔑", label: "Blockchain Address - For smart contract and wallet addresses" },
     handle:   { value: "did:handle", emoji: "👤", label: "Social Handle - X, GitHub, Discord, etc." },
     jwk:      { value: "did:jwk", emoji: "🔐", label: "JWK Key - Public key identifiers" },
-    artifact: { value: "did:artifact", emoji: "📦", label: "Artifact - For binaries, files, and text like JSON" },
+    artifact: { value: "did:artifact", emoji: "📦", label: "Content / File - Binaries, documents, configs (e.g. .json)" },
   }
 
   // Default fallback order (most common to least)

--- a/src/components/artifact-did-input.tsx
+++ b/src/components/artifact-did-input.tsx
@@ -1,9 +1,10 @@
 "use client"
 
 import React, { useState, useCallback, useRef, useEffect } from "react"
+import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Button } from "@/components/ui/button"
-import { artifactDidFromJson, artifactDidFromBytes } from "@oma3/omatrust/identity"
+import { artifactDidFromJson, artifactDidFromBytes, parseArtifactDid } from "@oma3/omatrust/identity"
 import { Upload, X } from "lucide-react"
 
 interface ArtifactDidInputProps {
@@ -20,9 +21,12 @@ interface ArtifactDidInputProps {
 /**
  * Artifact DID Input Component
  *
- * Upload a file to generate a content-addressed did:artifact identifier.
- * JSON files are canonicalized (JCS/RFC 8785) before hashing.
- * All other files are hashed as raw bytes.
+ * Two input modes:
+ * 1. Paste a did:artifact DID directly
+ * 2. Upload a file to generate the DID from content
+ *
+ * When a file is uploaded, the DID field updates automatically.
+ * When a DID is pasted, it is validated against the did:artifact format.
  */
 export function ArtifactDidInput({
   value = "",
@@ -30,20 +34,53 @@ export function ArtifactDidInput({
   error: externalError,
   className = "",
 }: ArtifactDidInputProps) {
+  const [didText, setDidText] = useState<string>(value || "")
   const [fileName, setFileName] = useState<string | null>(null)
   const [fileSize, setFileSize] = useState<number | null>(null)
-  const [resolvedDid, setResolvedDid] = useState<string | null>(value || null)
   const [internalError, setInternalError] = useState<string | null>(null)
   const [isProcessing, setIsProcessing] = useState(false)
   const [matchedAs, setMatchedAs] = useState<"json" | "binary" | null>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
 
-  // Sync resolved DID from external value on mount
+  // Sync from external value changes
   useEffect(() => {
-    if (value && value.startsWith("did:artifact:") && !resolvedDid) {
-      setResolvedDid(value)
+    if (value && value !== didText) {
+      setDidText(value)
     }
   }, [value]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Handle direct DID text input
+  const handleDidTextChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const text = e.target.value
+    setDidText(text)
+    setInternalError(null)
+
+    if (!text.trim()) {
+      onChange(null)
+      return
+    }
+
+    // Validate if it looks like a complete did:artifact
+    if (text.startsWith("did:artifact:")) {
+      try {
+        parseArtifactDid(text)
+        onChange(text)
+        // Clear file state since user typed directly
+        setFileName(null)
+        setFileSize(null)
+        setMatchedAs(null)
+      } catch (err) {
+        // Don't show error while typing — only if it looks complete but invalid
+        if (text.length > 20) {
+          setInternalError(err instanceof Error ? err.message : "Invalid did:artifact format")
+        }
+        onChange(null)
+      }
+    } else if (text.length > 5) {
+      setInternalError("Must start with did:artifact:")
+      onChange(null)
+    }
+  }
 
   const handleFileSelect = useCallback(async (file: File) => {
     setFileName(file.name)
@@ -74,11 +111,11 @@ export function ArtifactDidInput({
         setMatchedAs("binary")
       }
 
-      setResolvedDid(did)
+      setDidText(did)
       setInternalError(null)
       onChange(did)
     } catch (err) {
-      setResolvedDid(null)
+      setDidText("")
       setMatchedAs(null)
       setInternalError(err instanceof Error ? err.message : "Failed to process file")
       onChange(null)
@@ -109,7 +146,7 @@ export function ArtifactDidInput({
   const removeFile = () => {
     setFileName(null)
     setFileSize(null)
-    setResolvedDid(null)
+    setDidText("")
     setMatchedAs(null)
     setInternalError(null)
     onChange(null)
@@ -128,11 +165,25 @@ export function ArtifactDidInput({
 
   return (
     <div className={`space-y-3 ${className}`}>
+      {/* DID text input */}
       <div className="space-y-1">
-        <Label>Upload Artifact</Label>
+        <Label htmlFor="artifact-did">DID</Label>
+        <Input
+          id="artifact-did"
+          type="text"
+          value={didText}
+          onChange={handleDidTextChange}
+          placeholder="did:artifact:bafkrei..."
+          className="font-mono text-sm"
+        />
         <p className="text-xs text-muted-foreground">
-          Upload a file to generate its content-addressed identifier. JSON files are canonicalized before hashing. Examples: JSON configs, markdown documents, package manifests, firmware, applications.
+          Paste a DID, or upload a file below to generate one.
         </p>
+      </div>
+
+      {/* File upload section */}
+      <div className="space-y-1">
+        <Label>Or upload file</Label>
       </div>
 
       {hasFile ? (
@@ -140,9 +191,16 @@ export function ArtifactDidInput({
           <Upload className="h-5 w-5 shrink-0 text-muted-foreground" />
           <div className="flex-1 min-w-0">
             <p className="truncate text-sm font-medium text-foreground">{fileName}</p>
-            {fileSize !== null && (
-              <p className="text-xs text-muted-foreground">{formatFileSize(fileSize)}</p>
-            )}
+            <div className="flex items-center gap-2">
+              {fileSize !== null && (
+                <p className="text-xs text-muted-foreground">{formatFileSize(fileSize)}</p>
+              )}
+              {matchedAs && (
+                <p className="text-xs text-muted-foreground">
+                  · {matchedAs === "json" ? "canonical JSON" : "raw bytes"}
+                </p>
+              )}
+            </div>
           </div>
           <div className="flex shrink-0 gap-1">
             <Button
@@ -173,15 +231,15 @@ export function ArtifactDidInput({
         </div>
       ) : (
         <div
-          className={`flex flex-col items-center gap-2 rounded-lg border-2 border-dashed p-6 text-center transition-colors ${
+          className={`flex flex-col items-center gap-2 rounded-lg border-2 border-dashed p-4 text-center transition-colors ${
             showError ? "border-destructive" : "border-border hover:border-primary/50"
           }`}
           onDrop={handleDrop}
           onDragOver={handleDragOver}
         >
-          <Upload className="h-8 w-8 text-muted-foreground" />
+          <Upload className="h-6 w-6 text-muted-foreground" />
           <p className="text-sm text-muted-foreground">
-            Drag and drop a file here, or{" "}
+            Drag and drop, or{" "}
             <button
               type="button"
               onClick={() => fileInputRef.current?.click()}
@@ -210,18 +268,6 @@ export function ArtifactDidInput({
       {/* Error */}
       {showError && !isProcessing && (
         <p className="text-xs text-destructive">{errorMessage}</p>
-      )}
-
-      {/* Resolved DID */}
-      {resolvedDid && !isProcessing && (
-        <div className="rounded-md border border-border bg-muted/50 p-3">
-          <p className="mb-1 text-xs font-medium text-muted-foreground">
-            Generated did:artifact{matchedAs ? ` (${matchedAs === "json" ? "canonical JSON" : "raw bytes"})` : ""}:
-          </p>
-          <code className="block break-all text-xs font-mono text-foreground select-all">
-            {resolvedDid}
-          </code>
-        </div>
       )}
     </div>
   )

--- a/src/components/dashboard/PublishButton.tsx
+++ b/src/components/dashboard/PublishButton.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import Link from "next/link"
-import { ChevronDown, Star, Shield, KeyRound } from "lucide-react"
+import { ChevronDown, Star, FileCheck, MoreHorizontal } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import {
   DropdownMenu,
@@ -9,15 +9,20 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
-import { PUBLISH_MENU_ITEMS } from "@/config/publish-categories"
+import type { BackendSubject } from "@/lib/omatrust-backend"
 
-const menuIcons: Record<string, typeof Star> = {
-  review: Star,
-  issuer: Shield,
-  trust: KeyRound,
+interface PublishButtonProps {
+  /** Registered subjects for the current user — used to pre-fill forms */
+  subjects?: BackendSubject[]
 }
 
-export function PublishButton() {
+export function PublishButton({ subjects }: PublishButtonProps) {
+  // Pre-fill responsibleParty if the user has exactly one subject
+  const responsiblePartyDid = subjects?.length === 1 ? subjects[0].canonicalDid : null
+  const responsibilityClaimHref = responsiblePartyDid
+    ? `/publish/responsibility-claim?responsibleParty=${encodeURIComponent(responsiblePartyDid)}`
+    : "/publish/responsibility-claim"
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -27,17 +32,24 @@ export function PublishButton() {
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-52">
-        {PUBLISH_MENU_ITEMS.map((item) => {
-          const Icon = menuIcons[item.id]
-          return (
-            <DropdownMenuItem key={item.id} asChild>
-              <Link href={item.href} className="flex items-center gap-2">
-                {Icon && <Icon className="h-4 w-4" />}
-                {item.label}
-              </Link>
-            </DropdownMenuItem>
-          )
-        })}
+        <DropdownMenuItem asChild>
+          <Link href="/publish/user-review" className="flex items-center gap-2">
+            <Star className="h-4 w-4" />
+            User Review
+          </Link>
+        </DropdownMenuItem>
+        <DropdownMenuItem asChild>
+          <Link href={responsibilityClaimHref} className="flex items-center gap-2">
+            <FileCheck className="h-4 w-4" />
+            Content Claim
+          </Link>
+        </DropdownMenuItem>
+        <DropdownMenuItem asChild>
+          <Link href="/publish" className="flex items-center gap-2">
+            <MoreHorizontal className="h-4 w-4" />
+            Other attestations...
+          </Link>
+        </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
   )

--- a/src/config/publish-categories.ts
+++ b/src/config/publish-categories.ts
@@ -37,6 +37,11 @@ export const PUBLISH_MENU_ITEMS = [
     href: "/publish/user-review",
   },
   {
+    id: "claim",
+    label: "Responsibility Claim",
+    href: "/publish/responsibility-claim",
+  },
+  {
     id: "issuer",
     label: "Audit / Certification",
     href: "/publish?category=issuer",

--- a/src/config/publish-options.ts
+++ b/src/config/publish-options.ts
@@ -3,7 +3,7 @@ export interface PublishOption {
   title: string
   description: string
   href: string
-  icon: "star" | "shield" | "award" | "link" | "eye" | "key-round" | "message-square"
+  icon: "star" | "shield" | "award" | "file-check" | "link" | "eye" | "key-round" | "message-square"
   docsHref?: string
 }
 
@@ -14,6 +14,13 @@ export interface DashboardAction {
 }
 
 export const publishOptions: PublishOption[] = [
+  {
+    schemaId: "responsibility-claim",
+    title: "Publish a responsibility claim",
+    description: "Publicly accept responsibility for an artifact, service, or resource — as creator, distributor, or maintainer.",
+    href: "/publish/responsibility-claim",
+    icon: "file-check",
+  },
   {
     schemaId: "key-binding",
     title: "Authorize a signing key",

--- a/src/config/schemas.ts
+++ b/src/config/schemas.ts
@@ -518,6 +518,109 @@ const linkedIdentifierFields: FormField[] = [
   }
 ]
 
+const responsibilityClaimFields: FormField[] = [
+  {
+    "name": "responsibleParty",
+    "type": "string",
+    "label": "Responsible Party ID",
+    "description": "DID of the organization or identity publicly accepting responsibility. The attester must be an authorized key for this identity.",
+    "required": true,
+    "placeholder": "Select an ID type above",
+    "didMethods": [
+      "web",
+      "pkh",
+      "handle"
+    ],
+    "maxLength": 256,
+    "pattern": "^did:[a-z0-9]+:.+$",
+    "format": "did"
+  },
+  {
+    "name": "subject",
+    "type": "string",
+    "label": "Subject ID",
+    "description": "DID of the resource, service, application, agent, product, or artifact for which responsibility is being claimed.",
+    "required": true,
+    "placeholder": "Select an ID type above",
+    "didMethods": [
+      "web",
+      "pkh",
+      "jwk",
+      "artifact"
+    ],
+    "maxLength": 256,
+    "pattern": "^did:[a-z0-9]+:.+$",
+    "format": "did"
+  },
+  {
+    "name": "subjectLabel",
+    "type": "string",
+    "label": "Subject Label",
+    "description": "Human-readable label supplied by the responsible party to identify the subject. This value is descriptive metadata and is not part of the subject's cryptographic identity.",
+    "required": false,
+    "placeholder": "Enter subject label",
+    "minLength": 1,
+    "maxLength": 128
+  },
+  {
+    "name": "responsibilityType",
+    "type": "array",
+    "label": "Responsibility Type",
+    "description": "The complete current set of responsibilities the responsible party accepts for the subject. If responsibilities change, revoke this attestation and publish a replacement with a new array. Partial revocation of individual types is not supported.",
+    "required": true,
+    "placeholder": "Enter responsibility type",
+    "options": [
+      {
+        "value": "creator",
+        "label": "Creator",
+        "description": "Original author or maker of the subject. Asserts authorship of the resource."
+      },
+      {
+        "value": "distributor",
+        "label": "Distributor",
+        "description": "Responsible for delivering or distributing the subject through a channel. Covers publishing, mirroring, packaging, app store distribution, and CDN hosting."
+      },
+      {
+        "value": "maintainer",
+        "label": "Maintainer",
+        "description": "Actively maintains the subject. Implies ongoing responsibility for updates, patches, and security fixes."
+      }
+    ]
+  },
+  {
+    "name": "issuedAt",
+    "type": "integer",
+    "label": "Issued Date",
+    "description": "Time the responsibility claim was issued. Default is current time.",
+    "required": true,
+    "placeholder": "0",
+    "subtype": "timestamp",
+    "autoDefault": "current-timestamp",
+    "min": 0
+  },
+  {
+    "name": "effectiveAt",
+    "type": "integer",
+    "label": "Effective Date",
+    "description": "Time the responsibility claim becomes effective. Default is current time.",
+    "required": false,
+    "placeholder": "0",
+    "subtype": "timestamp",
+    "autoDefault": "current-timestamp",
+    "min": 0
+  },
+  {
+    "name": "expiresAt",
+    "type": "integer",
+    "label": "Expiration Date",
+    "description": "Time the responsibility claim expires. Default is no expiration.",
+    "required": false,
+    "placeholder": "0",
+    "subtype": "timestamp",
+    "min": 0
+  }
+]
+
 const securityAssessmentFields: FormField[] = [
   {
     "name": "subject",
@@ -922,6 +1025,27 @@ export const linkedIdentifierSchema: AttestationSchema = {
   }
 };
 
+export const responsibilityClaimSchema: AttestationSchema = {
+  id: 'responsibility-claim',
+  title: 'Responsibility Claim',
+  description: 'An identity, acting through an authorized key, publicly accepts one or more defined responsibilities for a subject.',
+  fields: responsibilityClaimFields,
+  revocable: true,
+  easSchemaString: 'string responsibleParty, string subject, string subjectLabel, string[] responsibilityType, string[] proofs, uint256 issuedAt, uint256 effectiveAt, uint256 expiresAt',
+  deployedUIDs: {
+    97: '0x0000000000000000000000000000000000000000000000000000000000000000', // BSC Testnet
+    56: '0x0000000000000000000000000000000000000000000000000000000000000000', // BSC Mainnet
+    66238: '0x877911f942a77a527661b288f8b0f6703fe461286bbf2e4a71967e2f2ec1b651', // OMAChain Testnet
+    6623: '0x0000000000000000000000000000000000000000000000000000000000000000'  // OMAChain Mainnet
+  },
+  deployedBlocks: {
+    97: 0, // BSC Testnet
+    56: 0, // BSC Mainnet
+    66238: 524, // OMAChain Testnet
+    6623: 0  // OMAChain Mainnet
+  }
+};
+
 export const securityAssessmentSchema: AttestationSchema = {
   id: 'security-assessment',
   title: 'Security Assessment',
@@ -992,6 +1116,7 @@ const allSchemas: AttestationSchema[] = [
   controllerWitnessSchema,
   keyBindingSchema,
   linkedIdentifierSchema,
+  responsibilityClaimSchema,
   securityAssessmentSchema,
   userReviewResponseSchema,
   userReviewSchema

--- a/src/lib/artifact-verification.ts
+++ b/src/lib/artifact-verification.ts
@@ -1,0 +1,487 @@
+/**
+ * Artifact Verification Library
+ *
+ * Implements Responsibility Claim verification for did:artifact subjects.
+ * This module will be extracted to the omatrust-sdk in Phase 2.
+ *
+ * See: docs/features/artifact/spec.md
+ * See: https://github.com/oma3dao/omatrust-sdk/issues/34
+ */
+
+import { parseArtifactDid } from '@oma3/omatrust/identity'
+import * as reputation from '@oma3/omatrust/reputation'
+import type {
+  Hex,
+  AttestationQueryResult,
+  ControllerAuthorizationResult,
+  VerifyAttestationResult,
+} from '@oma3/omatrust/reputation'
+import { getSchema, getAllSchemas } from '@/config/schemas'
+import { getActiveChain } from '@/lib/blockchain'
+import { getProviderAndEas, type EnrichedAttestationResult } from '@/lib/attestation-queries'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type VerifyResponsibilityClaimParams = {
+  attestation: AttestationQueryResult
+  artifactDid?: string
+  provider: unknown
+  easContractAddress?: Hex
+  chain?: string
+}
+
+export type VerifyResponsibilityClaimResult = {
+  valid: boolean
+  responsibleParty: string
+  controllerDid: string
+  responsibilityTypes: string[]
+  subjectLabel?: string
+  authorization: ControllerAuthorizationResult | null
+  checks: {
+    schemaValid: boolean
+    subjectMatches: boolean
+    notRevoked: boolean
+    currentlyEffective: boolean
+    controllerAuthorized: boolean
+    issuedDuringAuthorizationWindow: boolean
+  }
+  reasons: string[]
+}
+
+export type GetVerifiedArtifactAttestationsParams = {
+  artifactDid: string
+  provider?: unknown
+  easContractAddress?: Hex
+  chain?: string
+  schemas?: Hex[]
+  fromBlock?: number
+  limit?: number
+}
+
+export type VerifiedArtifactAttestation = {
+  attestation: EnrichedAttestationResult
+  verification?: VerifyAttestationResult
+}
+
+export type VerifiedResponsibilityClaim = {
+  attestation: EnrichedAttestationResult
+  verification: VerifyResponsibilityClaimResult
+}
+
+export type GetVerifiedArtifactAttestationsResult = {
+  artifactDid: string
+  responsibilityClaims: VerifiedResponsibilityClaim[]
+  securityAssessments: VerifiedArtifactAttestation[]
+  certifications: VerifiedArtifactAttestation[]
+  otherAttestations: VerifiedArtifactAttestation[]
+}
+
+export type IsArtifactClaimedByParams = {
+  artifactDid: string
+  responsibleParty: string
+  provider?: unknown
+  easContractAddress?: Hex
+  chain?: string
+  responsibilityTypes?: string[]
+}
+
+export type IsArtifactClaimedByResult = {
+  claimed: boolean
+  claims: VerifiedResponsibilityClaim[]
+  matchedResponsibilityTypes: string[]
+  reasons: string[]
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const RESPONSIBILITY_CLAIM_SCHEMA_ID = 'responsibility-claim'
+
+function getResponsibilityClaimSchemaString(): string {
+  const schema = getSchema(RESPONSIBILITY_CLAIM_SCHEMA_ID)
+  if (!schema?.easSchemaString) {
+    throw new Error('Responsibility Claim schema not found in config')
+  }
+  return schema.easSchemaString
+}
+
+function getResponsibilityClaimSchemaUid(chainId: number): Hex | null {
+  const schema = getSchema(RESPONSIBILITY_CLAIM_SCHEMA_ID)
+  const uid = schema?.deployedUIDs?.[chainId]
+  if (!uid || uid === '0x'.padEnd(66, '0')) return null
+  return uid as Hex
+}
+
+// ---------------------------------------------------------------------------
+// verifyResponsibilityClaim
+// ---------------------------------------------------------------------------
+
+export async function verifyResponsibilityClaim(
+  params: VerifyResponsibilityClaimParams
+): Promise<VerifyResponsibilityClaimResult> {
+  const { attestation, artifactDid, provider, easContractAddress, chain } = params
+  const reasons: string[] = []
+  const checks = {
+    schemaValid: false,
+    subjectMatches: false,
+    notRevoked: false,
+    currentlyEffective: false,
+    controllerAuthorized: false,
+    issuedDuringAuthorizationWindow: false,
+  }
+
+  // 1. Decode attestation data
+  let decoded: Record<string, unknown>
+  try {
+    const schemaString = getResponsibilityClaimSchemaString()
+    if (attestation.raw) {
+      decoded = reputation.decodeAttestationData(schemaString, attestation.raw)
+    } else if (attestation.data && typeof attestation.data === 'object') {
+      decoded = attestation.data as Record<string, unknown>
+    } else {
+      reasons.push('No attestation data available to decode')
+      return buildFailedResult(checks, reasons)
+    }
+  } catch (err) {
+    reasons.push(`Failed to decode attestation data: ${err instanceof Error ? err.message : 'unknown error'}`)
+    return buildFailedResult(checks, reasons)
+  }
+
+  // 2. Validate required fields
+  const responsibleParty = decoded.responsibleParty as string | undefined
+  const subject = decoded.subject as string | undefined
+  const responsibilityType = decoded.responsibilityType as string[] | undefined
+  const issuedAt = decoded.issuedAt as bigint | number | undefined
+  const effectiveAt = decoded.effectiveAt as bigint | number | undefined
+  const expiresAt = decoded.expiresAt as bigint | number | undefined
+  const subjectLabel = decoded.subjectLabel as string | undefined
+
+  if (!responsibleParty || !subject || !responsibilityType || !issuedAt) {
+    if (!responsibleParty) reasons.push('Missing required field: responsibleParty')
+    if (!subject) reasons.push('Missing required field: subject')
+    if (!responsibilityType) reasons.push('Missing required field: responsibilityType')
+    if (!issuedAt) reasons.push('Missing required field: issuedAt')
+    return buildFailedResult(checks, reasons, { responsibleParty, subject, subjectLabel, responsibilityType })
+  }
+
+  if (!Array.isArray(responsibilityType) || responsibilityType.length === 0) {
+    reasons.push('responsibilityType must be a non-empty array')
+    return buildFailedResult(checks, reasons, { responsibleParty, subject, subjectLabel, responsibilityType })
+  }
+
+  checks.schemaValid = true
+
+  // 3. Subject match check
+  if (artifactDid) {
+    checks.subjectMatches = subject.toLowerCase() === artifactDid.toLowerCase()
+    if (!checks.subjectMatches) {
+      reasons.push(`Subject "${subject}" does not match expected artifact "${artifactDid}"`)
+    }
+  } else {
+    // No cross-check requested
+    checks.subjectMatches = true
+  }
+
+  // 4. Revocation check
+  checks.notRevoked = attestation.revocationTime === BigInt(0)
+  if (!checks.notRevoked) {
+    reasons.push('Attestation has been revoked')
+  }
+
+  // 5. Effective/expiration date check
+  const now = BigInt(Math.floor(Date.now() / 1000))
+  const effectiveTime = toBigInt(effectiveAt)
+  const expirationTime = toBigInt(expiresAt)
+
+  const isEffective = effectiveTime === BigInt(0) || effectiveTime <= now
+  const isNotExpired = expirationTime === BigInt(0) || expirationTime > now
+  checks.currentlyEffective = isEffective && isNotExpired
+
+  if (!isEffective) {
+    reasons.push('Attestation is not yet effective')
+  }
+  if (!isNotExpired) {
+    reasons.push('Attestation has expired')
+  }
+
+  // 6. Derive controller DID from attester
+  const chainId = getActiveChain().id
+  const controllerDid = `did:pkh:eip155:${chainId}:${attestation.attester.toLowerCase()}`
+
+  // 7. Controller authorization
+  let authorization: ControllerAuthorizationResult | null = null
+  try {
+    const resolvedChain = chain ?? `eip155:${chainId}`
+    authorization = await reputation.getControllerAuthorization({
+      subjectDid: responsibleParty,
+      controllerDid,
+      provider,
+      chain: resolvedChain,
+      easContractAddress,
+    })
+
+    // 8. Check authorized
+    checks.controllerAuthorized = authorization.authorized
+    if (!checks.controllerAuthorized) {
+      reasons.push(`Controller ${controllerDid} is not authorized for ${responsibleParty}`)
+    }
+
+    // 9. Check issuedAt within authorization window
+    if (authorization.authorized && authorization.anchoredFrom !== null) {
+      const issuedAtBigInt = toBigInt(issuedAt)
+      const afterStart = issuedAtBigInt >= authorization.anchoredFrom
+      const beforeEnd = authorization.until === null || issuedAtBigInt <= authorization.until
+      checks.issuedDuringAuthorizationWindow = afterStart && beforeEnd
+
+      if (!afterStart) {
+        reasons.push('Attestation was issued before the authorization window started')
+      }
+      if (!beforeEnd) {
+        reasons.push('Attestation was issued after the authorization window ended')
+      }
+    } else if (authorization.authorized && authorization.anchoredFrom === null) {
+      // Authorization is live-only (DNS/did.json), no anchored window — accept
+      checks.issuedDuringAuthorizationWindow = true
+    } else {
+      // Not authorized — window check is moot
+      checks.issuedDuringAuthorizationWindow = false
+    }
+  } catch (err) {
+    reasons.push(`Controller authorization check failed: ${err instanceof Error ? err.message : 'unknown error'}`)
+    checks.controllerAuthorized = false
+    checks.issuedDuringAuthorizationWindow = false
+  }
+
+  const valid = Object.values(checks).every(Boolean)
+
+  return {
+    valid,
+    responsibleParty,
+    controllerDid,
+    responsibilityTypes: responsibilityType,
+    subjectLabel: subjectLabel || undefined,
+    authorization,
+    checks,
+    reasons,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// getVerifiedArtifactAttestations
+// ---------------------------------------------------------------------------
+
+export async function getVerifiedArtifactAttestations(
+  params: GetVerifiedArtifactAttestationsParams
+): Promise<GetVerifiedArtifactAttestationsResult> {
+  const { artifactDid, fromBlock, limit } = params
+
+  // Validate did:artifact input
+  parseArtifactDid(artifactDid) // throws if invalid
+
+  const chainId = getActiveChain().id
+  const { provider, easContractAddress } = getProviderAndEas(chainId)
+
+  // Get all deployed schema UIDs for this chain
+  const allSchemas = getAllSchemas()
+  const deployedSchemaUids = allSchemas
+    .map(s => s.deployedUIDs?.[chainId])
+    .filter((uid): uid is string => !!uid && uid !== '0x'.padEnd(66, '0')) as Hex[]
+
+  if (deployedSchemaUids.length === 0) {
+    return { artifactDid, responsibilityClaims: [], securityAssessments: [], certifications: [], otherAttestations: [] }
+  }
+
+  // Query all attestations for this artifact DID
+  const results = await reputation.listAttestations({
+    subjectDid: artifactDid,
+    provider,
+    easContractAddress,
+    schemas: deployedSchemaUids,
+    limit: limit ?? 100,
+    fromBlock,
+  })
+
+  // Group by schema
+  const responsibilityClaimUid = getResponsibilityClaimSchemaUid(chainId)
+  const securityAssessmentSchema = getSchema('security-assessment')
+  const certificationSchema = getSchema('certification')
+
+  const securityAssessmentUid = securityAssessmentSchema?.deployedUIDs?.[chainId]?.toLowerCase()
+  const certificationUid = certificationSchema?.deployedUIDs?.[chainId]?.toLowerCase()
+
+  const responsibilityClaims: VerifiedResponsibilityClaim[] = []
+  const securityAssessments: VerifiedArtifactAttestation[] = []
+  const certifications: VerifiedArtifactAttestation[] = []
+  const otherAttestations: VerifiedArtifactAttestation[] = []
+
+  for (const att of results) {
+    const schemaUidLower = att.schema.toLowerCase()
+    const enriched = enrichAttestation(att, chainId)
+
+    if (responsibilityClaimUid && schemaUidLower === responsibilityClaimUid.toLowerCase()) {
+      // Verify responsibility claim
+      const verification = await verifyResponsibilityClaim({
+        attestation: att,
+        artifactDid,
+        provider,
+        easContractAddress,
+        chain: params.chain,
+      })
+      responsibilityClaims.push({ attestation: enriched, verification })
+    } else if (securityAssessmentUid && schemaUidLower === securityAssessmentUid.toLowerCase()) {
+      const verification = await runStandardVerification(att, provider)
+      securityAssessments.push({ attestation: enriched, verification })
+    } else if (certificationUid && schemaUidLower === certificationUid.toLowerCase()) {
+      const verification = await runStandardVerification(att, provider)
+      certifications.push({ attestation: enriched, verification })
+    } else {
+      const verification = await runStandardVerification(att, provider)
+      otherAttestations.push({ attestation: enriched, verification })
+    }
+  }
+
+  return {
+    artifactDid,
+    responsibilityClaims,
+    securityAssessments,
+    certifications,
+    otherAttestations,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// isArtifactClaimedBy
+// ---------------------------------------------------------------------------
+
+export async function isArtifactClaimedBy(
+  params: IsArtifactClaimedByParams
+): Promise<IsArtifactClaimedByResult> {
+  const { artifactDid, responsibleParty, responsibilityTypes } = params
+
+  const result = await getVerifiedArtifactAttestations({
+    artifactDid,
+    provider: params.provider,
+    easContractAddress: params.easContractAddress,
+    chain: params.chain,
+  })
+
+  // Filter to claims from the specified responsible party
+  const matchingClaims = result.responsibilityClaims.filter(claim =>
+    claim.verification.responsibleParty.toLowerCase() === responsibleParty.toLowerCase()
+  )
+
+  // Only include claims that passed verification
+  const validClaims = matchingClaims.filter(claim => claim.verification.valid)
+
+  // Filter by responsibility types if specified
+  let finalClaims = validClaims
+  let matchedTypes: string[] = []
+
+  if (responsibilityTypes && responsibilityTypes.length > 0) {
+    finalClaims = validClaims.filter(claim =>
+      claim.verification.responsibilityTypes.some(t =>
+        responsibilityTypes.includes(t)
+      )
+    )
+    matchedTypes = [...new Set(
+      finalClaims.flatMap(claim =>
+        claim.verification.responsibilityTypes.filter(t =>
+          responsibilityTypes.includes(t)
+        )
+      )
+    )]
+  } else {
+    matchedTypes = [...new Set(
+      validClaims.flatMap(claim => claim.verification.responsibilityTypes)
+    )]
+  }
+
+  const reasons: string[] = []
+  if (finalClaims.length === 0) {
+    if (matchingClaims.length === 0) {
+      reasons.push(`No responsibility claims found from ${responsibleParty} for this artifact`)
+    } else if (validClaims.length === 0) {
+      reasons.push(`Claims from ${responsibleParty} exist but none passed verification`)
+    } else if (responsibilityTypes) {
+      reasons.push(`No claims matched the requested responsibility types: ${responsibilityTypes.join(', ')}`)
+    }
+  }
+
+  return {
+    claimed: finalClaims.length > 0,
+    claims: finalClaims,
+    matchedResponsibilityTypes: matchedTypes,
+    reasons,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function toBigInt(value: bigint | number | undefined): bigint {
+  if (value === undefined || value === null) return BigInt(0)
+  if (typeof value === 'bigint') return value
+  return BigInt(value)
+}
+
+function buildFailedResult(
+  checks: VerifyResponsibilityClaimResult['checks'],
+  reasons: string[],
+  decoded?: { responsibleParty?: string; subject?: string; subjectLabel?: string; responsibilityType?: string[] }
+): VerifyResponsibilityClaimResult {
+  return {
+    valid: false,
+    responsibleParty: decoded?.responsibleParty ?? '',
+    controllerDid: '',
+    responsibilityTypes: decoded?.responsibilityType ?? [],
+    subjectLabel: decoded?.subjectLabel || undefined,
+    authorization: null,
+    checks,
+    reasons,
+  }
+}
+
+function enrichAttestation(att: AttestationQueryResult, chainId: number): EnrichedAttestationResult {
+  const schema = getAllSchemas().find(s => s.deployedUIDs?.[chainId]?.toLowerCase() === att.schema.toLowerCase())
+
+  let decodedData = att.data as Record<string, unknown> | undefined
+  if (schema?.easSchemaString && att.raw) {
+    try {
+      decodedData = reputation.decodeAttestationData(schema.easSchemaString, att.raw)
+    } catch {
+      decodedData = att.data as Record<string, unknown>
+    }
+  }
+
+  return {
+    uid: att.uid,
+    schema: att.schema,
+    attester: att.attester,
+    recipient: att.recipient,
+    data: att.raw ?? '',
+    time: Number(att.time),
+    expirationTime: Number(att.expirationTime),
+    revocationTime: Number(att.revocationTime),
+    refUID: att.refUID,
+    revocable: att.revocable,
+    txHash: att.txHash,
+    schemaId: schema?.id,
+    schemaTitle: schema?.title,
+    decodedData,
+  }
+}
+
+async function runStandardVerification(
+  attestation: AttestationQueryResult,
+  provider: unknown
+): Promise<VerifyAttestationResult | undefined> {
+  try {
+    return await reputation.verifyAttestation({ attestation, provider })
+  } catch {
+    return undefined
+  }
+}

--- a/src/lib/attestation-queries.ts
+++ b/src/lib/attestation-queries.ts
@@ -303,12 +303,13 @@ export async function getLatestAttestationsWithMetadata(
  */
 const SCHEMA_PRIORITY: Record<string, number> = {
   'security-assessment': 0,
-  'certification': 1,
-  'controller-witness': 2,
-  'key-binding': 3,
-  'linked-identifier': 4,
-  'user-review-response': 5,
-  'user-review': 6,
+  'responsibility-claim': 1,
+  'certification': 2,
+  'controller-witness': 3,
+  'key-binding': 4,
+  'linked-identifier': 5,
+  'user-review-response': 6,
+  'user-review': 7,
 }
 
 const DEFAULT_PRIORITY = 4

--- a/tests/components/dashboard/PublishButton.test.tsx
+++ b/tests/components/dashboard/PublishButton.test.tsx
@@ -4,7 +4,6 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { PublishButton } from '@/components/dashboard/PublishButton';
-import { PUBLISH_MENU_ITEMS } from '@/config/publish-categories';
 
 vi.mock('next/link', () => ({
   default: ({ href, children, ...rest }: { href: string; children: React.ReactNode }) => (
@@ -23,9 +22,34 @@ describe('PublishButton', () => {
     render(<PublishButton />);
     await userEvent.click(screen.getByRole('button', { name: /Publish/i }));
 
-    for (const item of PUBLISH_MENU_ITEMS) {
-      const link = await screen.findByRole('menuitem', { name: item.label });
-      expect(link).toHaveAttribute('href', item.href);
-    }
+    const userReview = await screen.findByRole('menuitem', { name: /User Review/i });
+    expect(userReview).toHaveAttribute('href', '/publish/user-review');
+
+    const contentClaim = await screen.findByRole('menuitem', { name: /Content Claim/i });
+    expect(contentClaim).toHaveAttribute('href', '/publish/responsibility-claim');
+
+    const other = await screen.findByRole('menuitem', { name: /Other attestations/i });
+    expect(other).toHaveAttribute('href', '/publish');
+  });
+
+  it('pre-fills responsibleParty when user has exactly one subject', async () => {
+    const subjects = [{ id: '1', canonicalDid: 'did:web:example.com', subjectDidHash: 'abc', displayName: null, isDefault: true }];
+    render(<PublishButton subjects={subjects} />);
+    await userEvent.click(screen.getByRole('button', { name: /Publish/i }));
+
+    const contentClaim = await screen.findByRole('menuitem', { name: /Content Claim/i });
+    expect(contentClaim).toHaveAttribute('href', '/publish/responsibility-claim?responsibleParty=did%3Aweb%3Aexample.com');
+  });
+
+  it('does not pre-fill when user has multiple subjects', async () => {
+    const subjects = [
+      { id: '1', canonicalDid: 'did:web:a.com', subjectDidHash: 'a', displayName: null, isDefault: true },
+      { id: '2', canonicalDid: 'did:web:b.com', subjectDidHash: 'b', displayName: null, isDefault: false },
+    ];
+    render(<PublishButton subjects={subjects} />);
+    await userEvent.click(screen.getByRole('button', { name: /Publish/i }));
+
+    const contentClaim = await screen.findByRole('menuitem', { name: /Content Claim/i });
+    expect(contentClaim).toHaveAttribute('href', '/publish/responsibility-claim');
   });
 });

--- a/tests/config/schemas.test.ts
+++ b/tests/config/schemas.test.ts
@@ -309,7 +309,7 @@ describe('schemas config', () => {
   describe('getSchemaIds function', () => {
     it('returns all schema IDs', () => {
       const ids = getSchemaIds();
-      expect(ids).toEqual(['certification', 'common', 'controller-witness', 'key-binding', 'linked-identifier', 'security-assessment', 'user-review-response', 'user-review']);
+      expect(ids).toEqual(['certification', 'common', 'controller-witness', 'key-binding', 'linked-identifier', 'responsibility-claim', 'security-assessment', 'user-review-response', 'user-review']);
     });
 
     it('returns array of strings', () => {
@@ -324,7 +324,7 @@ describe('schemas config', () => {
   describe('getAllSchemas function', () => {
     it('returns all schemas', () => {
       const schemas = getAllSchemas();
-      expect(schemas).toHaveLength(8);
+      expect(schemas).toHaveLength(9);
       expect(schemas).toContain(certificationSchema);
       expect(schemas).toContain(commonSchema);
       expect(schemas).toContain(controllerWitnessSchema);


### PR DESCRIPTION
- Update schemas.ts with deployed Responsibility Claim schema UID
- Add responsibility-claim to schema priority ordering
- Add artifact verification library
- Add artifact subject type to verify page, hide controller input for artifacts
- Update ArtifactDidInput with paste-DID field + file upload
- Unhide Publish button on dashboard with Content Claim, User Review, Other
- Pre-fill responsibleParty from registered subject when user has exactly one
- Update tests

## Risk Level

**Risk:** low- all additive code. 

## Summary

We're enabling a whole new use case for OMATrust- attestations on content addressable DIDs 

## Testing Performed

Manual testing on local host, except for sending an attestation and automated tests 

## CI Status

- [x] All required checks pass

## Self-Merge

- [x] This is a self-merge

- **Reason for emergency self-merge:**

 Just going into staging.  Reveal will come when we push to main. 
