### PR TITLE
fix: hide signing key input immediately on artifact method selection

### DIFF
--- a/src/app/verify/page.tsx
+++ b/src/app/verify/page.tsx
@@ -138,6 +138,7 @@ function buildKeyAuthorization(
 export default function VerifyPage() {
   const [subjectDid, setSubjectDid] = useState("")
   const [controllerDid, setControllerDid] = useState("")
+  const [isArtifactMode, setIsArtifactMode] = useState(false)
   const [isVerifying, setIsVerifying] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [result, setResult] = useState<VerifyResult | null>(null)
@@ -246,12 +247,13 @@ export default function VerifyPage() {
             <SubjectIdInput
               value={subjectDid}
               onChange={(did) => setSubjectDid(did ?? "")}
+              onMethodChange={(method) => setIsArtifactMode(method === "artifact")}
               allowedMethods={["web", "pkh", "jwk", "artifact"]}
               className="ml-0"
             />
           </div>
 
-          {!subjectDid.startsWith("did:artifact:") && (
+          {!isArtifactMode && (
           <div>
             <div className="mb-2 flex items-center justify-between gap-3">
               <label className="text-sm font-medium text-foreground">Signing Key</label>

--- a/src/components/SubjectIdInput.tsx
+++ b/src/components/SubjectIdInput.tsx
@@ -21,6 +21,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 interface SubjectIdInputProps {
   value?: string
   onChange: (did: string | null) => void
+  onMethodChange?: (method: string) => void
   error?: string
   className?: string
   allowedMethods?: string[] // e.g. ["web", "pkh", "jwk", "key", "handle"]
@@ -37,6 +38,7 @@ type DidMethod = "did:web" | "did:pkh" | "did:handle" | "did:key" | "did:jwk" | 
 export function SubjectIdInput({
   value = "",
   onChange,
+  onMethodChange,
   error,
   className = "",
   allowedMethods,
@@ -106,6 +108,11 @@ export function SubjectIdInput({
 
     const nextMethod = newMethod as DidMethod
     setMethod(nextMethod)
+
+    // Notify parent of method change
+    if (onMethodChange) {
+      onMethodChange(nextMethod.replace("did:", ""))
+    }
 
     // Restore the draft for the new method, or null if none exists
     const draft = drafts[nextMethod] ?? null


### PR DESCRIPTION
## Risk Level

**Risk:** low

## Summary

Fixes hiding the signing key form when artifact is chosen

## Testing Performed

Manual on local host and automated tests 

## CI Status

- [x] All required checks pass

## Self-Merge

- [x] This is a self-merge

- **Reason for emergency self-merge:**

 Merging into staging
